### PR TITLE
fixing file not found exception in main class

### DIFF
--- a/src/main/java/ldbc/snb/datagen/generator/LDBCDatagen.java
+++ b/src/main/java/ldbc/snb/datagen/generator/LDBCDatagen.java
@@ -243,16 +243,15 @@ public class LDBCDatagen {
 
         try {
         Configuration conf = ConfigParser.initialize();
-        ConfigParser.readConfig(conf,"./src/main/resources/params.ini");
-        //ConfigParser.readConfig(conf,args[0]);
-        ConfigParser.readConfig(conf, "./params.ini");
+        ConfigParser.readConfig(conf, args[0]);
+        ConfigParser.readConfig(conf, LDBCDatagen.class.getResourceAsStream("/params.ini"));
         conf.set("ldbc.snb.datagen.serializer.hadoopDir",conf.get("ldbc.snb.datagen.serializer.outputDir")+"/hadoop");
         conf.set("ldbc.snb.datagen.serializer.socialNetworkDir",conf.get("ldbc.snb.datagen.serializer.outputDir")+"/social_network");
         ConfigParser.printConfig(conf);
 //        conf.setBoolean("mapreduce.map.output.compress", true);
 //       conf.setBoolean("mapreduce.output.fileoutputformat.compress", false);
 
-        // Deleting exisging files
+        // Deleting existing files
         FileSystem dfs = FileSystem.get(conf);
         dfs.delete(new Path(conf.get("ldbc.snb.datagen.serializer.hadoopDir")), true);
         dfs.delete(new Path(conf.get("ldbc.snb.datagen.serializer.socialNetworkDir")), true);

--- a/src/main/java/ldbc/snb/datagen/util/ConfigParser.java
+++ b/src/main/java/ldbc/snb/datagen/util/ConfigParser.java
@@ -10,6 +10,8 @@ import org.w3c.dom.NodeList;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Map;
 import java.util.Properties;
@@ -82,10 +84,21 @@ public class ConfigParser {
         return conf;
     }
 
-    public static Configuration readConfig(Configuration conf, String paramsFile) {
+    public static Configuration readConfig(Configuration conf, String paramsFile ) {
+        try {
+            readConfig(conf, new FileInputStream(paramsFile));
+        } catch (FileNotFoundException e) {
+            System.err.println(e.getMessage());
+            e.printStackTrace();
+            System.exit(-1);
+        }
+        return conf;
+    }
+
+    public static Configuration readConfig(Configuration conf, InputStream paramStream ) {
         try {
             Properties properties = new Properties();
-            properties.load(new InputStreamReader(new FileInputStream(paramsFile), "UTF-8"));
+            properties.load(new InputStreamReader(paramStream, "UTF-8"));
             String val = (String) properties.get("ldbc.snb.datagen.generator.scaleFactor");
             if( val != null ) {
                 ScaleFactor scaleFactor = scaleFactors.get(val);


### PR DESCRIPTION
The assembled jar file threw a file not found exception for "./src/main/resources/params.ini" when executing on a cluster. Furthermore, the params file given by argument was not read because the code is commented. The class is now reading the params.ini containing the default settings as a resource, so it works locally and in an executable jar.
