### PR TITLE
Added CSVCompositePersonSerializer that composites emails and languages

### DIFF
--- a/src/main/java/ldbc/snb/datagen/serializer/snb/interactive/CSVCompositeInvariantSerializer.java
+++ b/src/main/java/ldbc/snb/datagen/serializer/snb/interactive/CSVCompositeInvariantSerializer.java
@@ -35,19 +35,14 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
 package ldbc.snb.datagen.serializer.snb.interactive;
 
-import ldbc.snb.datagen.dictionary.Dictionaries;
 import ldbc.snb.datagen.objects.Organization;
 import ldbc.snb.datagen.objects.Place;
 import ldbc.snb.datagen.objects.Tag;
 import ldbc.snb.datagen.objects.TagClass;
-import ldbc.snb.datagen.serializer.HDFSCSVWriter;
 import ldbc.snb.datagen.serializer.InvariantSerializer;
-import ldbc.snb.datagen.vocabulary.DBP;
-import ldbc.snb.datagen.vocabulary.DBPOWL;
 import org.apache.hadoop.conf.Configuration;
 
 import java.io.IOException;
-import java.util.ArrayList;
 
 /**
  * Created by aprat on 12/17/14.

--- a/src/main/java/ldbc/snb/datagen/serializer/snb/interactive/CSVCompositeInvariantSerializer.java
+++ b/src/main/java/ldbc/snb/datagen/serializer/snb/interactive/CSVCompositeInvariantSerializer.java
@@ -1,0 +1,94 @@
+/* 
+ Copyright (c) 2013 LDBC
+ Linked Data Benchmark Council (http://www.ldbcouncil.org)
+ 
+ This file is part of ldbc_snb_datagen.
+ 
+ ldbc_snb_datagen is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ ldbc_snb_datagen is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with ldbc_snb_datagen.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ Copyright (C) 2011 OpenLink Software <bdsmt@openlinksw.com>
+ All Rights Reserved.
+ 
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation;  only Version 2 of the License dated
+ June 1991.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
+package ldbc.snb.datagen.serializer.snb.interactive;
+
+import ldbc.snb.datagen.dictionary.Dictionaries;
+import ldbc.snb.datagen.objects.Organization;
+import ldbc.snb.datagen.objects.Place;
+import ldbc.snb.datagen.objects.Tag;
+import ldbc.snb.datagen.objects.TagClass;
+import ldbc.snb.datagen.serializer.HDFSCSVWriter;
+import ldbc.snb.datagen.serializer.InvariantSerializer;
+import ldbc.snb.datagen.vocabulary.DBP;
+import ldbc.snb.datagen.vocabulary.DBPOWL;
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+/**
+ * Created by aprat on 12/17/14.
+ */
+public class CSVCompositeInvariantSerializer extends InvariantSerializer {
+
+    private CSVInvariantSerializer invariantSerializer = new CSVInvariantSerializer();
+
+    @Override
+    public void initialize(Configuration conf, int reducerId) throws IOException {
+        invariantSerializer.initialize(conf, reducerId);
+    }
+
+    @Override
+    public void close() {
+        invariantSerializer.close();
+    }
+
+    @Override
+    protected void serialize(final Place place) {
+        invariantSerializer.serialize(place);
+    }
+
+    @Override
+    protected void serialize(final Organization organization) {
+        invariantSerializer.serialize(organization);
+    }
+
+    @Override
+    protected void serialize(final TagClass tagClass) {
+        invariantSerializer.serialize(tagClass);
+    }
+
+    @Override
+    protected void serialize(final Tag tag) {
+        invariantSerializer.serialize(tag);
+    }
+
+    @Override
+    public void reset() {
+        // Intentionally left empty
+
+    }
+}

--- a/src/main/java/ldbc/snb/datagen/serializer/snb/interactive/CSVCompositePersonActivitySerializer.java
+++ b/src/main/java/ldbc/snb/datagen/serializer/snb/interactive/CSVCompositePersonActivitySerializer.java
@@ -35,14 +35,11 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
 package ldbc.snb.datagen.serializer.snb.interactive;
 
-import ldbc.snb.datagen.dictionary.Dictionaries;
 import ldbc.snb.datagen.objects.*;
-import ldbc.snb.datagen.serializer.HDFSCSVWriter;
 import ldbc.snb.datagen.serializer.PersonActivitySerializer;
 import org.apache.hadoop.conf.Configuration;
 
 import java.io.IOException;
-import java.util.ArrayList;
 
 /**
  * @author aprat

--- a/src/main/java/ldbc/snb/datagen/serializer/snb/interactive/CSVCompositePersonActivitySerializer.java
+++ b/src/main/java/ldbc/snb/datagen/serializer/snb/interactive/CSVCompositePersonActivitySerializer.java
@@ -1,0 +1,99 @@
+/* 
+ Copyright (c) 2013 LDBC
+ Linked Data Benchmark Council (http://www.ldbcouncil.org)
+ 
+ This file is part of ldbc_snb_datagen.
+ 
+ ldbc_snb_datagen is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ ldbc_snb_datagen is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with ldbc_snb_datagen.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ Copyright (C) 2011 OpenLink Software <bdsmt@openlinksw.com>
+ All Rights Reserved.
+ 
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation;  only Version 2 of the License dated
+ June 1991.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
+package ldbc.snb.datagen.serializer.snb.interactive;
+
+import ldbc.snb.datagen.dictionary.Dictionaries;
+import ldbc.snb.datagen.objects.*;
+import ldbc.snb.datagen.serializer.HDFSCSVWriter;
+import ldbc.snb.datagen.serializer.PersonActivitySerializer;
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+/**
+ * @author aprat
+ */
+public class CSVCompositePersonActivitySerializer extends PersonActivitySerializer {
+
+    CSVPersonActivitySerializer activitySerializer = new CSVPersonActivitySerializer();
+
+    @Override
+    public void initialize(Configuration conf, int reducerId) throws IOException {
+        activitySerializer.initialize(conf, reducerId);
+    }
+
+    @Override
+    public void close() {
+        activitySerializer.close();
+    }
+
+    @Override
+    protected void serialize(final Forum forum) {
+        activitySerializer.serialize(forum);
+    }
+
+    @Override
+    protected void serialize(final Post post) {
+        activitySerializer.serialize(post);
+    }
+
+    @Override
+    protected void serialize(final Comment comment) {
+        activitySerializer.serialize(comment);
+    }
+
+    @Override
+    protected void serialize(final Photo photo) {
+        activitySerializer.serialize(photo);
+    }
+
+    @Override
+    protected void serialize(final ForumMembership membership) {
+        activitySerializer.serialize(membership);
+    }
+
+    @Override
+    protected void serialize(final Like like) {
+        activitySerializer.serialize(like);
+    }
+
+    @Override
+    public void reset() {
+        // Intentionally left empty
+    }
+
+}

--- a/src/main/java/ldbc/snb/datagen/serializer/snb/interactive/CSVCompositePersonActivitySerializer.java
+++ b/src/main/java/ldbc/snb/datagen/serializer/snb/interactive/CSVCompositePersonActivitySerializer.java
@@ -46,7 +46,7 @@ import java.io.IOException;
  */
 public class CSVCompositePersonActivitySerializer extends PersonActivitySerializer {
 
-    CSVPersonActivitySerializer activitySerializer = new CSVPersonActivitySerializer();
+    private CSVPersonActivitySerializer activitySerializer = new CSVPersonActivitySerializer();
 
     @Override
     public void initialize(Configuration conf, int reducerId) throws IOException {

--- a/src/main/java/ldbc/snb/datagen/serializer/snb/interactive/CSVCompositePersonSerializer.java
+++ b/src/main/java/ldbc/snb/datagen/serializer/snb/interactive/CSVCompositePersonSerializer.java
@@ -1,0 +1,232 @@
+/* 
+ Copyright (c) 2013 LDBC
+ Linked Data Benchmark Council (http://www.ldbcouncil.org)
+ 
+ This file is part of ldbc_snb_datagen.
+ 
+ ldbc_snb_datagen is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+ 
+ ldbc_snb_datagen is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with ldbc_snb_datagen.  If not, see <http://www.gnu.org/licenses/>.
+ 
+ Copyright (C) 2011 OpenLink Software <bdsmt@openlinksw.com>
+ All Rights Reserved.
+ 
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation;  only Version 2 of the License dated
+ June 1991.
+ 
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+ 
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
+
+
+package ldbc.snb.datagen.serializer.snb.interactive;
+
+import ldbc.snb.datagen.dictionary.Dictionaries;
+import ldbc.snb.datagen.objects.Knows;
+import ldbc.snb.datagen.objects.Person;
+import ldbc.snb.datagen.objects.StudyAt;
+import ldbc.snb.datagen.objects.WorkAt;
+import ldbc.snb.datagen.serializer.HDFSCSVWriter;
+import ldbc.snb.datagen.serializer.PersonSerializer;
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+
+public class CSVCompositePersonSerializer extends PersonSerializer {
+
+    private HDFSCSVWriter[] writers;
+
+    private enum FileNames {
+        PERSON("person"),
+        PERSON_LOCATED_IN_PLACE("person_isLocatedIn_place"),
+        PERSON_HAS_INTEREST_TAG("person_hasInterest_tag"),
+        PERSON_WORK_AT("person_workAt_organisation"),
+        PERSON_STUDY_AT("person_studyAt_organisation"),
+        PERSON_KNOWS_PERSON("person_knows_person");
+
+        private final String name;
+
+        private FileNames(String name) {
+            this.name = name;
+        }
+
+        public String toString() {
+            return name;
+        }
+    }
+
+    @Override
+    public void initialize(Configuration conf, int reducerId) throws IOException {
+        int numFiles = FileNames.values().length;
+        writers = new HDFSCSVWriter[numFiles];
+        for (int i = 0; i < numFiles; ++i) {
+            writers[i] = new HDFSCSVWriter(conf.get("ldbc.snb.datagen.serializer.socialNetworkDir"), FileNames
+                    .values()[i].toString() + "_" + reducerId, conf
+                                                   .getInt("ldbc.snb.datagen.serializer.numPartitions", 1), conf
+                                                   .getBoolean("ldbc.snb.datagen.serializer.compressed", false), "|", conf
+                                                   .getBoolean("ldbc.snb.datagen.serializer.endlineSeparator", false));
+        }
+
+        ArrayList<String> arguments = new ArrayList<String>();
+        arguments.add("id");
+        arguments.add("firstName");
+        arguments.add("lastName");
+        arguments.add("gender");
+        arguments.add("birthday");
+        arguments.add("creationDate");
+        arguments.add("locationIP");
+        arguments.add("browserUsed");
+        arguments.add("language");
+        arguments.add("email");
+        writers[FileNames.PERSON.ordinal()].writeHeader(arguments);
+
+        arguments.clear();
+        arguments.add("Person.id");
+        arguments.add("Place.id");
+        writers[FileNames.PERSON_LOCATED_IN_PLACE.ordinal()].writeHeader(arguments);
+
+        arguments.clear();
+        arguments.add("Person.id");
+        arguments.add("Tag.id");
+        writers[FileNames.PERSON_HAS_INTEREST_TAG.ordinal()].writeHeader(arguments);
+
+        arguments.clear();
+        arguments.add("Person.id");
+        arguments.add("Organisation.id");
+        arguments.add("workFrom");
+        writers[FileNames.PERSON_WORK_AT.ordinal()].writeHeader(arguments);
+
+        arguments.clear();
+        arguments.add("Person.id");
+        arguments.add("Organisation.id");
+        arguments.add("classYear");
+        writers[FileNames.PERSON_STUDY_AT.ordinal()].writeHeader(arguments);
+
+        arguments.clear();
+        arguments.add("Person.id");
+        arguments.add("Person.id");
+        arguments.add("creationDate");
+        writers[FileNames.PERSON_KNOWS_PERSON.ordinal()].writeHeader(arguments);
+
+    }
+
+    @Override
+    public void close() {
+        int numFiles = FileNames.values().length;
+        for (int i = 0; i < numFiles; ++i) {
+            writers[i].close();
+        }
+    }
+
+    @Override
+    protected void serialize(final Person p) {
+
+        ArrayList<String> arguments = new ArrayList<String>();
+
+        arguments.add(Long.toString(p.accountId()));
+        arguments.add(p.firstName());
+        arguments.add(p.lastName());
+        if (p.gender() == 1) {
+            arguments.add("male");
+        } else {
+            arguments.add("female");
+        }
+
+        String dateString = Dictionaries.dates.formatDate(p.birthDay());
+        arguments.add(dateString);
+
+        dateString = Dictionaries.dates.formatDateTime(p.creationDate());
+        arguments.add(dateString);
+        arguments.add(p.ipAddress().toString());
+        arguments.add(Dictionaries.browsers.getName(p.browserId()));
+
+        ArrayList<Integer> languages = p.languages();
+        StringBuilder languagesBuilder = new StringBuilder();
+        for (int i = 0; i < languages.size()-1; i++) {
+            languagesBuilder.append(Dictionaries.languages.getLanguageName(languages.get(i))+";");
+        }
+        if(languages.size() > 0) {
+            languagesBuilder.append(Dictionaries.languages.getLanguageName(languages.get(languages.size()-1)));
+        }
+        arguments.add(languagesBuilder.toString());
+
+        StringBuilder emailsBuilder = new StringBuilder();
+        Iterator<String> itString = p.emails().iterator();
+        for (int i = 0; i < p.emails().size()-1; i++) {
+            emailsBuilder.append(itString.next()+";");
+        }
+        if(itString.hasNext()) {
+            emailsBuilder.append(itString.next());
+        }
+        arguments.add(emailsBuilder.toString());
+
+        writers[FileNames.PERSON.ordinal()].writeEntry(arguments);
+
+        arguments.clear();
+        arguments.add(Long.toString(p.accountId()));
+        arguments.add(Integer.toString(p.cityId()));
+        writers[FileNames.PERSON_LOCATED_IN_PLACE.ordinal()].writeEntry(arguments);
+
+        Iterator<Integer> itInteger = p.interests().iterator();
+        while (itInteger.hasNext()) {
+            arguments.clear();
+            Integer interestIdx = itInteger.next();
+            arguments.add(Long.toString(p.accountId()));
+            arguments.add(Integer.toString(interestIdx));
+            writers[FileNames.PERSON_HAS_INTEREST_TAG.ordinal()].writeEntry(arguments);
+        }
+    }
+
+    @Override
+    protected void serialize(final StudyAt studyAt) {
+        ArrayList<String> arguments = new ArrayList<String>();
+        String dateString = Dictionaries.dates.formatYear(studyAt.year);
+        arguments.add(Long.toString(studyAt.user));
+        arguments.add(Long.toString(studyAt.university));
+        arguments.add(dateString);
+        writers[FileNames.PERSON_STUDY_AT.ordinal()].writeEntry(arguments);
+    }
+
+    @Override
+    protected void serialize(final WorkAt workAt) {
+        ArrayList<String> arguments = new ArrayList<String>();
+        String dateString = Dictionaries.dates.formatYear(workAt.year);
+        arguments.add(Long.toString(workAt.user));
+        arguments.add(Long.toString(workAt.company));
+        arguments.add(dateString);
+        writers[FileNames.PERSON_WORK_AT.ordinal()].writeEntry(arguments);
+    }
+
+    @Override
+    protected void serialize(final Person p, Knows knows) {
+        ArrayList<String> arguments = new ArrayList<String>();
+        String dateString = Dictionaries.dates.formatDateTime(knows.creationDate());
+        arguments.add(Long.toString(p.accountId()));
+        arguments.add(Long.toString(knows.to().accountId()));
+        arguments.add(dateString);
+        writers[FileNames.PERSON_KNOWS_PERSON.ordinal()].writeEntry(arguments);
+    }
+
+    @Override
+    public void reset() {
+        // Intentionally left empty
+    }
+}


### PR DESCRIPTION
This Pull request adds a CSVCompositePersonSerializer, that instead of creating the emails and language files, it adds two columns to person_?_?.csv files with the list of languages and emails respectively, separated by semi-colons (;)