### PR TITLE
Throw RuntimeExceptions to fail as early as possible

### DIFF
--- a/src/main/java/ldbc/snb/datagen/LdbcDatagen.java
+++ b/src/main/java/ldbc/snb/datagen/LdbcDatagen.java
@@ -348,7 +348,6 @@ public class LdbcDatagen {
         } catch (Exception e) {
             System.err.println("Error during execution");
             System.err.println(e.getMessage());
-            e.printStackTrace();
             throw e;
         }
     }

--- a/src/main/java/ldbc/snb/datagen/dictionary/BrowserDictionary.java
+++ b/src/main/java/ldbc/snb/datagen/dictionary/BrowserDictionary.java
@@ -73,7 +73,7 @@ public class BrowserDictionary {
             }
             dictionary.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/ldbc/snb/datagen/dictionary/CompanyDictionary.java
+++ b/src/main/java/ldbc/snb/datagen/dictionary/CompanyDictionary.java
@@ -114,7 +114,7 @@ public class CompanyDictionary {
             }
             dictionary.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/ldbc/snb/datagen/dictionary/EmailDictionary.java
+++ b/src/main/java/ldbc/snb/datagen/dictionary/EmailDictionary.java
@@ -86,7 +86,7 @@ public class EmailDictionary {
             }
             emailDictionary.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/ldbc/snb/datagen/dictionary/IPAddressDictionary.java
+++ b/src/main/java/ldbc/snb/datagen/dictionary/IPAddressDictionary.java
@@ -119,7 +119,7 @@ public class IPAddressDictionary {
                 ipZoneFile.close();
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/ldbc/snb/datagen/dictionary/LanguageDictionary.java
+++ b/src/main/java/ldbc/snb/datagen/dictionary/LanguageDictionary.java
@@ -124,7 +124,7 @@ public class LanguageDictionary {
             }
             dictionary.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/ldbc/snb/datagen/dictionary/NamesDictionary.java
+++ b/src/main/java/ldbc/snb/datagen/dictionary/NamesDictionary.java
@@ -110,7 +110,7 @@ public class NamesDictionary {
             surnameDictionary.close();
             System.out.println("Done ... " + totalSurNames + " surnames were extracted ");
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 
@@ -140,7 +140,7 @@ public class NamesDictionary {
             givennameDictionary.close();
             System.out.println("Done ... " + totalGivenNames + " given names were extracted ");
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/ldbc/snb/datagen/dictionary/PlaceDictionary.java
+++ b/src/main/java/ldbc/snb/datagen/dictionary/PlaceDictionary.java
@@ -291,7 +291,7 @@ public class PlaceDictionary {
             }
             dictionary.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 
@@ -331,7 +331,7 @@ public class PlaceDictionary {
             cumulativeDistribution = new Float[temporalCumulative.size()];
             cumulativeDistribution = temporalCumulative.toArray(cumulativeDistribution);
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 
@@ -372,7 +372,7 @@ public class PlaceDictionary {
             }
             dictionary.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/ldbc/snb/datagen/dictionary/PopularPlacesDictionary.java
+++ b/src/main/java/ldbc/snb/datagen/dictionary/PopularPlacesDictionary.java
@@ -107,7 +107,7 @@ public class PopularPlacesDictionary {
             }
             dicPopularPlace.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/ldbc/snb/datagen/dictionary/TagDictionary.java
+++ b/src/main/java/ldbc/snb/datagen/dictionary/TagDictionary.java
@@ -227,7 +227,7 @@ public class TagDictionary {
 
             dictionary.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/ldbc/snb/datagen/dictionary/TagMatrix.java
+++ b/src/main/java/ldbc/snb/datagen/dictionary/TagMatrix.java
@@ -95,7 +95,7 @@ public class TagMatrix {
             }
             dictionary.close();
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/ldbc/snb/datagen/dictionary/TagTextDictionary.java
+++ b/src/main/java/ldbc/snb/datagen/dictionary/TagTextDictionary.java
@@ -83,7 +83,7 @@ public class TagTextDictionary {
             }
             dictionary.close();
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/ldbc/snb/datagen/dictionary/UniversityDictionary.java
+++ b/src/main/java/ldbc/snb/datagen/dictionary/UniversityDictionary.java
@@ -135,7 +135,7 @@ public class UniversityDictionary {
             }
             dicAllInstitutes.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/ldbc/snb/datagen/dictionary/UserAgentDictionary.java
+++ b/src/main/java/ldbc/snb/datagen/dictionary/UserAgentDictionary.java
@@ -77,7 +77,7 @@ public class UserAgentDictionary {
             }
             agentFile.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/ldbc/snb/datagen/generator/distribution/EmpiricalDistribution.java
+++ b/src/main/java/ldbc/snb/datagen/generator/distribution/EmpiricalDistribution.java
@@ -64,10 +64,9 @@ public class EmpiricalDistribution extends BucketedDistribution {
             reader.close();
             return Bucket.bucketizeHistogram(histogram, 1000);
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-        return null;
     }
 }

--- a/src/main/java/ldbc/snb/datagen/generator/distribution/FacebookDegreeDistribution.java
+++ b/src/main/java/ldbc/snb/datagen/generator/distribution/FacebookDegreeDistribution.java
@@ -83,9 +83,9 @@ public class FacebookDegreeDistribution extends BucketedDistribution {
             }
             fbDataReader.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } catch (Exception e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/ldbc/snb/datagen/generator/generators/PersonActivityGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/PersonActivityGenerator.java
@@ -98,7 +98,6 @@ public class PersonActivityGenerator {
         } catch (AssertionError e) {
             System.out.println("Assertion error when generating activity!");
             System.out.println(e.getMessage());
-            e.printStackTrace();
             throw e;
         }
     }

--- a/src/main/java/ldbc/snb/datagen/generator/generators/knowsgenerators/BterKnowsGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/knowsgenerators/BterKnowsGenerator.java
@@ -183,7 +183,7 @@ public class BterKnowsGenerator implements KnowsGenerator {
             }
             reader.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
 
         p[0] = 0.0;

--- a/src/main/java/ldbc/snb/datagen/hadoop/generator/HadoopKnowsGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/generator/HadoopKnowsGenerator.java
@@ -105,7 +105,7 @@ public class HadoopKnowsGenerator {
                                                                        .newInstance();
             } catch (Exception e) {
                 System.out.println(e.getMessage());
-                e.printStackTrace();
+                throw new RuntimeException(e);
             }
         }
 

--- a/src/main/java/ldbc/snb/datagen/hadoop/generator/HadoopPersonActivityGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/generator/HadoopPersonActivityGenerator.java
@@ -107,7 +107,7 @@ public class HadoopPersonActivityGenerator {
 
             } catch (Exception e) {
                 System.err.println(e.getMessage());
-                e.printStackTrace();
+                throw new RuntimeException(e);
             }
         }
 
@@ -148,7 +148,6 @@ public class HadoopPersonActivityGenerator {
                 personFactors_.close();
                 friends_.close();
             } catch (IOException e) {
-                e.printStackTrace();
                 throw new RuntimeException(e);
             }
             dynamicActivitySerializer_.close();
@@ -217,7 +216,7 @@ public class HadoopPersonActivityGenerator {
             fs.delete(new Path(conf.get("ldbc.snb.datagen.serializer.hadoopDir") + "/aux"), true);
         } catch (IOException e) {
             System.err.println(e.getMessage());
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/ldbc/snb/datagen/hadoop/generator/HadoopPersonGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/generator/HadoopPersonGenerator.java
@@ -77,7 +77,7 @@ public class HadoopPersonGenerator {
             } catch (Exception e) {
                 System.err.println("Error when setting key setter");
                 System.err.println(e.getMessage());
-                e.printStackTrace();
+                throw new RuntimeException(e);
             }
 
             int threadId = Integer.parseInt(value.toString());
@@ -135,7 +135,7 @@ public class HadoopPersonGenerator {
                 output.write((new String(i + "\n").getBytes()));
             output.close();
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/ldbc/snb/datagen/hadoop/miscjob/HadoopFileRanker.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/miscjob/HadoopFileRanker.java
@@ -90,13 +90,13 @@ public class HadoopFileRanker {
                 keySetter = (HadoopFileKeyChanger.KeySetter) Class.forName(className).newInstance();
             } catch (ClassNotFoundException e) {
                 System.out.print(e.getMessage());
-                e.printStackTrace();
+                throw new RuntimeException(e);
             } catch (IllegalAccessException e) {
                 System.out.print(e.getMessage());
-                e.printStackTrace();
+                throw new RuntimeException(e);
             } catch (InstantiationException e) {
                 System.out.print(e.getMessage());
-                e.printStackTrace();
+                throw new RuntimeException(e);
             }
         }
 
@@ -194,7 +194,7 @@ public class HadoopFileRanker {
                 }
             } catch (IOException e) {
                 System.err.println(e.getMessage());
-                e.printStackTrace();
+                throw new RuntimeException(e);
             }
 
             counters[0] = 0;

--- a/src/main/java/ldbc/snb/datagen/hadoop/miscjob/HadoopMergeFriendshipFiles.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/miscjob/HadoopMergeFriendshipFiles.java
@@ -75,7 +75,7 @@ public class HadoopMergeFriendshipFiles {
                                                                        .newInstance();
             } catch (Exception e) {
                 System.out.println(e.getMessage());
-                e.printStackTrace();
+                throw new RuntimeException(e);
             }
         }
 

--- a/src/main/java/ldbc/snb/datagen/hadoop/miscjob/keychanger/HadoopFileKeyChanger.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/miscjob/keychanger/HadoopFileKeyChanger.java
@@ -77,13 +77,13 @@ public class HadoopFileKeyChanger {
                 keySetter = (HadoopFileKeyChanger.KeySetter) Class.forName(className).newInstance();
             } catch (ClassNotFoundException e) {
                 System.out.print(e.getMessage());
-                e.printStackTrace();
+                throw new RuntimeException(e);
             } catch (IllegalAccessException e) {
                 System.out.print(e.getMessage());
-                e.printStackTrace();
+                throw new RuntimeException(e);
             } catch (InstantiationException e) {
                 System.out.print(e.getMessage());
-                e.printStackTrace();
+                throw new RuntimeException(e);
             }
         }
 

--- a/src/main/java/ldbc/snb/datagen/hadoop/serializer/HadoopPersonSerializer.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/serializer/HadoopPersonSerializer.java
@@ -88,7 +88,7 @@ public class HadoopPersonSerializer {
                 }
             } catch (Exception e) {
                 System.err.println(e.getMessage());
-                e.printStackTrace();
+                throw new RuntimeException(e);
             }
         }
 

--- a/src/main/java/ldbc/snb/datagen/hadoop/serializer/HadoopPersonSortAndSerializer.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/serializer/HadoopPersonSortAndSerializer.java
@@ -94,7 +94,7 @@ public class HadoopPersonSortAndSerializer {
                 }
             } catch (Exception e) {
                 System.err.println(e.getMessage());
-                e.printStackTrace();
+                throw new RuntimeException(e);
             }
         }
 

--- a/src/main/java/ldbc/snb/datagen/hadoop/serializer/HadoopStaticSerializer.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/serializer/HadoopStaticSerializer.java
@@ -75,7 +75,7 @@ public class HadoopStaticSerializer {
             }
         } catch (Exception e) {
             System.err.println(e.getMessage());
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
 
         exportPlaces();

--- a/src/main/java/ldbc/snb/datagen/hadoop/serializer/HadoopUpdateStreamSerializer.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/serializer/HadoopUpdateStreamSerializer.java
@@ -77,7 +77,7 @@ public class HadoopUpdateStreamSerializer {
                 }
             } catch (Exception e) {
                 System.err.println(e.getMessage());
-                e.printStackTrace();
+                throw new RuntimeException(e);
             }
         }
 

--- a/src/main/java/ldbc/snb/datagen/hadoop/writer/HdfsWriter.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/writer/HdfsWriter.java
@@ -81,7 +81,7 @@ public class HdfsWriter {
             currentPartition = ++currentPartition % numPartitions;
         } catch (IOException e) {
             System.out.println("Cannot write to output file ");
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 
@@ -92,7 +92,7 @@ public class HdfsWriter {
             }
         } catch (IOException e) {
             System.out.println("Cannot write to output file ");
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/ldbc/snb/datagen/util/ConfigParser.java
+++ b/src/main/java/ldbc/snb/datagen/util/ConfigParser.java
@@ -162,8 +162,7 @@ public class ConfigParser {
             }
         } catch (Exception e) {
             System.err.println(e.getMessage());
-            e.printStackTrace();
-            System.exit(-1);
+            throw new RuntimeException(e);
         }
         return conf;
     }

--- a/src/main/java/ldbc/snb/datagen/util/Distribution.java
+++ b/src/main/java/ldbc/snb/datagen/util/Distribution.java
@@ -70,7 +70,7 @@ public class Distribution {
                 ++index;
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/ldbc/snb/datagen/util/DistributionKey.java
+++ b/src/main/java/ldbc/snb/datagen/util/DistributionKey.java
@@ -94,7 +94,7 @@ public class DistributionKey {
             }
 
         } catch (IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/ldbc/snb/datagen/util/FactorTable.java
+++ b/src/main/java/ldbc/snb/datagen/util/FactorTable.java
@@ -403,11 +403,11 @@ public class FactorTable {
         } catch (AssertionError e) {
             System.err.println("Unable to write parameter counts");
             System.err.println(e.getMessage());
-            e.printStackTrace();
+            throw new RuntimeException(e);
         } catch (IOException e) {
             System.err.println("Unable to write parameter counts");
             System.err.println(e.getMessage());
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 
@@ -474,7 +474,6 @@ public class FactorTable {
         } catch (IOException e) {
             System.err.println("Unable to write parameter counts");
             System.err.println(e.getMessage());
-            e.printStackTrace();
             throw e;
         }
     }

--- a/src/test/java/ldbc/snb/datagen/test/LdbcDatagenTest.java
+++ b/src/test/java/ldbc/snb/datagen/test/LdbcDatagenTest.java
@@ -41,7 +41,6 @@ public class LdbcDatagenTest {
             LdbcDatagen datagen = new LdbcDatagen();
             datagen.runGenerateJob(conf);
         } catch (Exception e) {
-            e.printStackTrace();
             throw e;
         }
     }


### PR DESCRIPTION
The previous version called printStackTrace() and kept running until
causing another exception such as an NPE


Let me know if this seems alright with you.
