### PR TITLE
Spark PoC

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,11 +38,6 @@
       <version>1.1.3</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-client</artifactId>
-      <version>3.2.1</version>
-    </dependency>
-    <dependency>
       <groupId>ca.umontreal.iro</groupId>
       <artifactId>ssj</artifactId>
       <version>2.5</version>
@@ -81,6 +76,16 @@
       <groupId>org.roaringbitmap</groupId>
       <artifactId>RoaringBitmap</artifactId>
       <version>0.6.18</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_2.11</artifactId>
+      <version>2.4.5</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-sql_2.11</artifactId>
+      <version>2.4.5</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/src/main/java/ldbc/snb/datagen/generator/generators/PersonGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/PersonGenerator.java
@@ -40,9 +40,11 @@ import ldbc.snb.datagen.dictionary.Dictionaries;
 import ldbc.snb.datagen.entities.dynamic.person.Person;
 import ldbc.snb.datagen.generator.distribution.DegreeDistribution;
 import ldbc.snb.datagen.generator.tools.PowerDistribution;
+import ldbc.snb.datagen.hadoop.key.TupleKey;
 import ldbc.snb.datagen.util.RandomGeneratorFarm;
 import ldbc.snb.datagen.vocabulary.SN;
 import org.apache.hadoop.conf.Configuration;
+import scala.Tuple2;
 
 import java.text.Normalizer;
 import java.util.GregorianCalendar;
@@ -190,14 +192,27 @@ public class PersonGenerator {
      * @param blockSize The size of the block of persons to generate.
      * @return block of persons
      */
-    public Person[] generatePersonBlock(int seed, int blockSize) {
+    public Tuple2<TupleKey, Person>[] generatePersonBlock(int seed, int blockSize) {
+        Tuple2<TupleKey, Person>[] block = new Tuple2[blockSize];
+        return generatePersonBlock(seed, blockSize, block);
+    }
+
+    public Tuple2<TupleKey, Person>[] generatePersonBlock(int seed, int blockSize, Tuple2<TupleKey, Person>[] block) {
+        return generatePersonBlock(seed, blockSize, block, 0);
+    }
+
+    public Tuple2<TupleKey, Person>[] generatePersonBlock(int seed, int blockSize, Tuple2<TupleKey, Person>[] block, int offset) {
+        if (offset < 0 || offset >= block.length) {
+            throw new RuntimeException("Offset out of bounds");
+        }
+        if (offset + blockSize > block.length) {
+            throw new RuntimeException("End out of bounds");
+        }
         resetState(seed);
         nextId = seed * blockSize;
         SN.machineId = seed;
-        Person[] block;
-        block = new Person[blockSize];
         for (int j = 0; j < blockSize; ++j) {
-            block[j] = generatePerson();
+            block[j + offset] = new Tuple2<TupleKey, Person>(null, generatePerson());
         }
         return block;
     }

--- a/src/main/java/ldbc/snb/datagen/hadoop/generator/HadoopPersonGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/generator/HadoopPersonGenerator.java
@@ -36,141 +36,95 @@
 package ldbc.snb.datagen.hadoop.generator;
 
 import ldbc.snb.datagen.DatagenParams;
-import ldbc.snb.datagen.LdbcDatagen;
 import ldbc.snb.datagen.entities.dynamic.person.Person;
 import ldbc.snb.datagen.generator.generators.PersonGenerator;
 import ldbc.snb.datagen.hadoop.key.TupleKey;
 import ldbc.snb.datagen.hadoop.miscjob.keychanger.HadoopFileKeyChanger;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.io.LongWritable;
-import org.apache.hadoop.io.Text;
-import org.apache.hadoop.mapreduce.Job;
-import org.apache.hadoop.mapreduce.Mapper;
-import org.apache.hadoop.mapreduce.Reducer;
-import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
-import org.apache.hadoop.mapreduce.lib.input.NLineInputFormat;
-import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
-import org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat;
+import org.apache.hadoop.mapred.SequenceFileOutputFormat;
+import org.apache.spark.api.java.JavaPairRDD;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.function.PairFlatMapFunction;
+import scala.Tuple2;
 
-import java.io.IOException;
-import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class HadoopPersonGenerator {
 
     private Configuration conf = null;
 
-    public static class HadoopPersonGeneratorMapper extends Mapper<LongWritable, Text, TupleKey, Person> {
+    private JavaSparkContext ctx = null;
 
-        private HadoopFileKeyChanger.KeySetter<TupleKey> keySetter = null;
-
-        @Override
-        public void map(LongWritable key, Text value, Context context)
-                throws IOException, InterruptedException {
-
-            Configuration conf = context.getConfiguration();
-
-            try {
-                this.keySetter = (HadoopFileKeyChanger.KeySetter) Class.forName(conf.get("postKeySetterName")).newInstance();
-            } catch (Exception e) {
-                System.err.println("Error when setting key setter");
-                System.err.println(e.getMessage());
-                throw new RuntimeException(e);
-            }
-
-            int threadId = Integer.parseInt(value.toString());
-            System.out.println("Generating person at mapper " + threadId);
-            LdbcDatagen.initializeContext(conf);
-
-            // Here we determine the blocks in the "block space" that this mapper is responsible for.
-            int numBlocks = (int) (Math.ceil(DatagenParams.numPersons / (double) DatagenParams.blockSize));
-            int initBlock = (int) (Math.ceil((numBlocks / (double) DatagenParams.numThreads) * threadId));
-            int endBlock = (int) (Math.ceil((numBlocks / (double) DatagenParams.numThreads) * (threadId + 1)));
-
-            PersonGenerator personGenerator = new PersonGenerator(conf, conf
-                    .get("ldbc.snb.datagen.generator.distribution.degreeDistribution"));
-            for (int i = initBlock; i < endBlock; ++i) {
-                Person[] block = personGenerator.generatePersonBlock(i, DatagenParams.blockSize);
-                int size = block.length;
-                for (int j = 0; j < size && DatagenParams.blockSize * i + j < DatagenParams.numPersons; ++j) {
-                    try {
-                        context.write(keySetter.getKey(block[j]), block[j]);
-                    } catch (IOException ioE) {
-                        System.err.println("Input/Output Exception when writing to context.");
-                        ioE.printStackTrace();
-                    } catch (InterruptedException iE) {
-                        System.err.println("Interrupted Exception when writing to context.");
-                        iE.printStackTrace();
-                    }
-                }
-            }
-        }
-    }
-
-
-    public static class HadoopPersonGeneratorReducer extends Reducer<TupleKey, Person, TupleKey, Person> {
-
-        @Override
-        public void reduce(TupleKey key, Iterable<Person> valueSet,
-                           Context context) throws IOException, InterruptedException {
-            for (Person person : valueSet) {
-                context.write(key, person);
-            }
-        }
-    }
-
-
-    public HadoopPersonGenerator(Configuration conf) {
-        this.conf = new Configuration(conf);
-    }
-
-    private static void writeToOutputFile(String filename, int numMaps, Configuration conf) {
-        try {
-            FileSystem dfs = FileSystem.get(conf);
-            OutputStream output = dfs.create(new Path(filename));
-            for (int i = 0; i < numMaps; i++)
-                output.write((i + "\n").getBytes());
-            output.close();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+    public HadoopPersonGenerator(JavaSparkContext ctx) {
+        this.conf = ctx.hadoopConfiguration();
+        this.ctx = ctx;
     }
 
     /**
      * Generates a Person hadoop sequence file containing key-value paiers
      * where the key is the person id and the value is the person itself.
      *
-     * @param outputFileName The name of the file to store the persons.
      * @throws Exception
      */
     public void run(String outputFileName, String postKeySetterName) throws Exception {
 
-        String hadoopDir = conf.get("ldbc.snb.datagen.serializer.hadoopDir");
-        String tempFile = hadoopDir + "/mrInputFile";
+        int numBlocks = (int) (Math.ceil(DatagenParams.numPersons / (double) DatagenParams.blockSize));
 
-        FileSystem dfs = FileSystem.get(conf);
-        dfs.delete(new Path(tempFile), true);
-        writeToOutputFile(tempFile, Integer.parseInt(conf.get("ldbc.snb.datagen.generator.numThreads")), conf);
+        PairFlatMapFunction<Iterator<Integer>, TupleKey, Person> personPartitionGenerator = (PairFlatMapFunction<Iterator<Integer>, TupleKey, Person>) tIterator -> {
+            PersonGenerator personGenerator = new PersonGenerator(conf, conf
+                    .get("ldbc.snb.datagen.generator.distribution.degreeDistribution"));
 
-        int numThreads = Integer.parseInt(conf.get("ldbc.snb.datagen.generator.numThreads"));
-        conf.setInt("mapreduce.input.lineinputformat.linespermap", 1);
+            HadoopFileKeyChanger.KeySetter<TupleKey> keySetter = null;
+
+            try {
+                keySetter = (HadoopFileKeyChanger.KeySetter) Class.forName(conf.get("postKeySetterName")).newInstance();
+            } catch (Exception e) {
+                System.err.println("Error when setting key setter");
+                System.err.println(e.getMessage());
+                throw new RuntimeException(e);
+            }
+
+            // Normally you would like exactly one block/partition, but let's support the general case
+
+            if (!tIterator.hasNext()) {
+                return Collections.emptyIterator();
+            }
+
+            int startBlock = tIterator.next();
+            int endBlock = startBlock + 1;
+
+            while (tIterator.hasNext()) {
+                tIterator.next();
+                endBlock++;
+            }
+
+            int blocksInPartition = endBlock - startBlock;
+
+            Tuple2<TupleKey, Person>[] blocks = new Tuple2[blocksInPartition * DatagenParams.blockSize];
+
+            for (int i = 0; i < blocksInPartition; ++i) {
+                personGenerator.generatePersonBlock(i + startBlock, DatagenParams.blockSize, blocks, i * DatagenParams.blockSize);
+
+                // replace the null keys. this whole thing is done in this unclean way so we don't have to allocate a new array
+                for (int j = 0; j < DatagenParams.blockSize; ++j) {
+                    int elemIdx = i * DatagenParams.blockSize + j;
+                    blocks[elemIdx] = new Tuple2(keySetter.getKey(blocks[elemIdx]), blocks[elemIdx]);
+                }
+            }
+
+            return Arrays.stream(blocks).iterator();
+        };
+
         conf.set("postKeySetterName", postKeySetterName);
-        Job job = Job.getInstance(conf, "SIB Generate Persons & 1st Dimension");
-        job.setMapOutputKeyClass(TupleKey.class);
-        job.setMapOutputValueClass(Person.class);
-        job.setOutputKeyClass(TupleKey.class);
-        job.setOutputValueClass(Person.class);
-        job.setJarByClass(HadoopPersonGeneratorMapper.class);
-        job.setMapperClass(HadoopPersonGeneratorMapper.class);
-        job.setReducerClass(HadoopPersonGeneratorReducer.class);
-        job.setNumReduceTasks(numThreads);
-        job.setInputFormatClass(NLineInputFormat.class);
-        job.setOutputFormatClass(SequenceFileOutputFormat.class);
-        FileInputFormat.setInputPaths(job, new Path(tempFile));
-        FileOutputFormat.setOutputPath(job, new Path(outputFileName));
-        if (!job.waitForCompletion(true)) {
-            throw new IllegalStateException("HadoopPersonGenerator failed");
-        }
+
+        JavaPairRDD<TupleKey, Person> persons = ctx
+                .parallelize(IntStream.range(0, numBlocks).boxed().collect(Collectors.toList()), numBlocks)
+                .mapPartitionsToPair(personPartitionGenerator, true);
+
+        persons.saveAsHadoopFile(outputFileName, TupleKey.class, Person.class, SequenceFileOutputFormat.class);
     }
 }

--- a/src/test/java/ldbc/snb/datagen/test/LdbcDatagenTest.java
+++ b/src/test/java/ldbc/snb/datagen/test/LdbcDatagenTest.java
@@ -16,6 +16,8 @@ import ldbc.snb.datagen.test.csv.StringParser;
 import ldbc.snb.datagen.test.csv.UniquenessCheck;
 import ldbc.snb.datagen.util.ConfigParser;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.spark.SparkContext;
+import org.apache.spark.api.java.JavaSparkContext;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -39,7 +41,9 @@ public class LdbcDatagenTest {
             LdbcDatagen.prepareConfiguration(conf);
             LdbcDatagen.initializeContext(conf);
             LdbcDatagen datagen = new LdbcDatagen();
-            datagen.runGenerateJob(conf);
+            // TODO configure properly
+            JavaSparkContext ctx = JavaSparkContext.fromSparkContext(SparkContext.getOrCreate());
+            datagen.runGenerateJob(ctx);
         } catch (Exception e) {
             throw e;
         }


### PR DESCRIPTION
Shows you a way to generate persons with Spark without changing much of the codebase.

- [ ] Proper blocksize checking
- [ ] Configure Spark properly

Design decisions: I used mapPartitions so I can set the partition size to be smaller than `numBlocks` and still process multiple blocks with a single pass. This makes sense if multiple blocks fit into memory, because it's faster to create a big array of persons than multiple small ones. However if the block size can be arbitrarily chosen, then you would simply choose a number just the right size and directly use `numBlocks` as the partition number (note that I actually did this, see the second argument of `parallelize`) and spare the hassle with iterating the integers, offseting into an array, etc., you get the point. In Spark the unit of parallelization is the partition, so `numThreads` does not make sense. The lower bound for parallelization is the partition count, so you want to fiddle with that.