### PR TITLE
Get rid of Hadoop Configuration in runtime agnostic parts of the codebase

### DIFF
--- a/base-docker-image/pom.xml
+++ b/base-docker-image/pom.xml
@@ -117,7 +117,7 @@
         <configuration>
           <archive>
             <manifest>
-              <mainClass>ldbc.snb.datagen.LdbcDatagen</mainClass>
+              <mainClass>ldbc.snb.datagen.hadoop.LdbcDatagen</mainClass>
             </manifest>
           </archive>
           <descriptorRefs>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <configuration>
           <archive>
             <manifest>
-              <mainClass>ldbc.snb.datagen.LdbcDatagen</mainClass>
+              <mainClass>ldbc.snb.datagen.hadoop.LdbcDatagen</mainClass>
             </manifest>
           </archive>
           <descriptorRefs>

--- a/src/main/java/ldbc/snb/datagen/DatagenParams.java
+++ b/src/main/java/ldbc/snb/datagen/DatagenParams.java
@@ -38,7 +38,7 @@
 package ldbc.snb.datagen;
 
 import ldbc.snb.datagen.generator.distribution.DegreeDistribution;
-import org.apache.hadoop.conf.Configuration;
+import ldbc.snb.datagen.util.Config;
 
 public class DatagenParams {
 
@@ -230,10 +230,15 @@ public class DatagenParams {
     public static int numPartitions = 1;
     public static int numUpdatePartitions = 1;
 
-    private static Integer intConf(Configuration conf,ParameterNames param) { return Integer.parseInt(conf.get(param.toString())); }
-    private static Double doubleConf(Configuration conf,ParameterNames param) { return Double.parseDouble(conf.get(param.toString())); }
+    private static Integer intConf(Config conf, ParameterNames param) {
+        return Integer.parseInt(conf.get(param.toString()));
+    }
 
-    public static void readConf(Configuration conf) {
+    private static Double doubleConf(Config conf, ParameterNames param) {
+        return Double.parseDouble(conf.get(param.toString()));
+    }
+
+    public static void readConf(Config conf) {
         try {
             ParameterNames[] values = ParameterNames.values();
             for (ParameterNames value : values)

--- a/src/main/java/ldbc/snb/datagen/dictionary/Dictionaries.java
+++ b/src/main/java/ldbc/snb/datagen/dictionary/Dictionaries.java
@@ -36,8 +36,8 @@
 package ldbc.snb.datagen.dictionary;
 
 import ldbc.snb.datagen.DatagenParams;
+import ldbc.snb.datagen.util.Config;
 import ldbc.snb.datagen.util.DateUtils;
-import org.apache.hadoop.conf.Configuration;
 
 import java.util.GregorianCalendar;
 
@@ -59,7 +59,7 @@ public class Dictionaries {
     public static FlashmobTagDictionary flashmobs = null;
 
 
-    public static void loadDictionaries(Configuration conf) {
+    public static void loadDictionaries(Config conf) {
 
         browsers = new BrowserDictionary(DatagenParams.probAnotherBrowser);
 

--- a/src/main/java/ldbc/snb/datagen/generator/distribution/AltmannDistribution.java
+++ b/src/main/java/ldbc/snb/datagen/generator/distribution/AltmannDistribution.java
@@ -36,7 +36,7 @@
 package ldbc.snb.datagen.generator.distribution;
 
 import ldbc.snb.datagen.DatagenParams;
-import org.apache.hadoop.conf.Configuration;
+import ldbc.snb.datagen.util.Config;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,7 +48,7 @@ public class AltmannDistribution extends CumulativeBasedDegreeDistribution {
     private double BETA_ = 0.0162;
 
 
-    public List<CumulativeEntry> cumulativeProbability(Configuration conf) {
+    public List<CumulativeEntry> cumulativeProbability(Config conf) {
         ALPHA_ = conf.getDouble("ldbc.snb.datagen.generator.distribution.AltmannDistribution.alpha", ALPHA_);
         BETA_ = conf.getDouble("ldbc.snb.datagen.generator.distribution.AltmannDistribution.beta", BETA_);
 

--- a/src/main/java/ldbc/snb/datagen/generator/distribution/BucketedDistribution.java
+++ b/src/main/java/ldbc/snb/datagen/generator/distribution/BucketedDistribution.java
@@ -36,7 +36,7 @@
 package ldbc.snb.datagen.generator.distribution;
 
 import ldbc.snb.datagen.generator.tools.Bucket;
-import org.apache.hadoop.conf.Configuration;
+import ldbc.snb.datagen.util.Config;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -48,9 +48,9 @@ public abstract class BucketedDistribution extends DegreeDistribution {
     private List<Random> randomDegree;
     private Random randomPercentile;
 
-    public abstract List<Bucket> getBuckets(Configuration conf);
+    public abstract List<Bucket> getBuckets(Config conf);
 
-    public void initialize(Configuration conf) {
+    public void initialize(Config conf) {
         buckets = this.getBuckets(conf);
         randomPercentile = new Random(0);
         randomDegree = new ArrayList<>();

--- a/src/main/java/ldbc/snb/datagen/generator/distribution/CumulativeBasedDegreeDistribution.java
+++ b/src/main/java/ldbc/snb/datagen/generator/distribution/CumulativeBasedDegreeDistribution.java
@@ -35,7 +35,7 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
 package ldbc.snb.datagen.generator.distribution;
 
-import org.apache.hadoop.conf.Configuration;
+import ldbc.snb.datagen.util.Config;
 
 import java.util.List;
 import java.util.Random;
@@ -50,7 +50,7 @@ public abstract class CumulativeBasedDegreeDistribution extends DegreeDistributi
         public int value_;
     }
 
-    public void initialize(Configuration conf) {
+    public void initialize(Config conf) {
         cumulativeProbability_ = cumulativeProbability(conf);
         random_ = new Random();
     }
@@ -80,5 +80,5 @@ public abstract class CumulativeBasedDegreeDistribution extends DegreeDistributi
         return midPoint;
     }
 
-    public abstract List<CumulativeEntry> cumulativeProbability(Configuration conf);
+    public abstract List<CumulativeEntry> cumulativeProbability(Config conf);
 }

--- a/src/main/java/ldbc/snb/datagen/generator/distribution/DegreeDistribution.java
+++ b/src/main/java/ldbc/snb/datagen/generator/distribution/DegreeDistribution.java
@@ -35,11 +35,11 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
 package ldbc.snb.datagen.generator.distribution;
 
-import org.apache.hadoop.conf.Configuration;
+import ldbc.snb.datagen.util.Config;
 
 public abstract class DegreeDistribution {
 
-    public abstract void initialize(Configuration conf);
+    public abstract void initialize(Config conf);
 
     public abstract void reset(long seed);
 

--- a/src/main/java/ldbc/snb/datagen/generator/distribution/DiscreteWeibullDistribution.java
+++ b/src/main/java/ldbc/snb/datagen/generator/distribution/DiscreteWeibullDistribution.java
@@ -36,7 +36,7 @@
 package ldbc.snb.datagen.generator.distribution;
 
 import ldbc.snb.datagen.DatagenParams;
-import org.apache.hadoop.conf.Configuration;
+import ldbc.snb.datagen.util.Config;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,7 +46,7 @@ public class DiscreteWeibullDistribution extends CumulativeBasedDegreeDistributi
     private double BETA_ = 0.8505;
     private double P_ = 0.0205;
 
-    public List<CumulativeEntry> cumulativeProbability(Configuration conf) {
+    public List<CumulativeEntry> cumulativeProbability(Config conf) {
         BETA_ = conf.getDouble("ldbc.snb.datagen.generator.distribution.DiscreteWeibullDistribution.beta", BETA_);
         P_ = conf.getDouble("ldbc.snb.datagen.generator.distribution.DiscreteWeibullDistribution.p", P_);
         List<CumulativeEntry> cumulative = new ArrayList<>();

--- a/src/main/java/ldbc/snb/datagen/generator/distribution/EmpiricalDistribution.java
+++ b/src/main/java/ldbc/snb/datagen/generator/distribution/EmpiricalDistribution.java
@@ -36,8 +36,8 @@
 package ldbc.snb.datagen.generator.distribution;
 
 import ldbc.snb.datagen.generator.tools.Bucket;
+import ldbc.snb.datagen.util.Config;
 import org.apache.commons.math3.util.Pair;
-import org.apache.hadoop.conf.Configuration;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -50,7 +50,7 @@ public class EmpiricalDistribution extends BucketedDistribution {
     private String fileName = null;
 
     @Override
-    public List<Bucket> getBuckets(Configuration conf) {
+    public List<Bucket> getBuckets(Config conf) {
         fileName = conf.get("ldbc.snb.datagen.generator.distribution.EmpiricalDistribution.fileName");
         List<Pair<Integer, Integer>> histogram = new ArrayList<>();
         try {

--- a/src/main/java/ldbc/snb/datagen/generator/distribution/FacebookDegreeDistribution.java
+++ b/src/main/java/ldbc/snb/datagen/generator/distribution/FacebookDegreeDistribution.java
@@ -38,10 +38,9 @@ package ldbc.snb.datagen.generator.distribution;
 
 import ldbc.snb.datagen.DatagenParams;
 import ldbc.snb.datagen.generator.tools.Bucket;
-import org.apache.hadoop.conf.Configuration;
+import ldbc.snb.datagen.util.Config;
 
 import java.io.BufferedReader;
-import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -65,7 +64,7 @@ public class FacebookDegreeDistribution extends BucketedDistribution {
     private List<Bucket> buckets;
 
     @Override
-    public List<Bucket> getBuckets(Configuration conf) {
+    public List<Bucket> getBuckets(Config conf) {
         mean = (int) mean(DatagenParams.numPersons);
         buckets = new ArrayList<>();
         loadFBBuckets();

--- a/src/main/java/ldbc/snb/datagen/generator/distribution/GeoDistribution.java
+++ b/src/main/java/ldbc/snb/datagen/generator/distribution/GeoDistribution.java
@@ -35,8 +35,8 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
 package ldbc.snb.datagen.generator.distribution;
 
+import ldbc.snb.datagen.util.Config;
 import org.apache.commons.math3.distribution.GeometricDistribution;
-import org.apache.hadoop.conf.Configuration;
 
 
 public class GeoDistribution extends DegreeDistribution {
@@ -44,7 +44,7 @@ public class GeoDistribution extends DegreeDistribution {
     private GeometricDistribution geo_;
     private double ALPHA_ = 0.12;
 
-    public void initialize(Configuration conf) {
+    public void initialize(Config conf) {
         ALPHA_ = conf.getDouble("ldbc.snb.datagen.generator.distribution.GeoDistribution.alpha", ALPHA_);
         geo_ = new GeometricDistribution(ALPHA_);
     }

--- a/src/main/java/ldbc/snb/datagen/generator/distribution/MoeZipfDistribution.java
+++ b/src/main/java/ldbc/snb/datagen/generator/distribution/MoeZipfDistribution.java
@@ -35,7 +35,7 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
 package ldbc.snb.datagen.generator.distribution;
 
-import org.apache.hadoop.conf.Configuration;
+import ldbc.snb.datagen.util.Config;
 
 import java.util.Random;
 
@@ -46,7 +46,7 @@ public class MoeZipfDistribution extends DegreeDistribution {
     private double DELTA_ = 1.5;
     private Random random_;
 
-    public void initialize(Configuration conf) {
+    public void initialize(Config conf) {
         ALPHA_ = conf.getDouble("ldbc.snb.datagen.generator.distribution.MoeZipfDistribution.alpha", ALPHA_);
         DELTA_ = conf.getDouble("ldbc.snb.datagen.generator.distribution.MoeZipfDistribution.delta", DELTA_);
         zipf_ = new org.apache.commons.math3.distribution.ZipfDistribution(5000, ALPHA_);

--- a/src/main/java/ldbc/snb/datagen/generator/distribution/ZipfDistribution.java
+++ b/src/main/java/ldbc/snb/datagen/generator/distribution/ZipfDistribution.java
@@ -35,7 +35,7 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
 package ldbc.snb.datagen.generator.distribution;
 
-import org.apache.hadoop.conf.Configuration;
+import ldbc.snb.datagen.util.Config;
 
 import java.util.Arrays;
 import java.util.Comparator;
@@ -55,7 +55,7 @@ public class ZipfDistribution extends DegreeDistribution {
     private int maxDegree = 1000;
     private int numSamples = 10000;
 
-    public void initialize(Configuration conf) {
+    public void initialize(Config conf) {
         ALPHA_ = conf.getDouble("ldbc.snb.datagen.generator.distribution.ZipfDistribution.alpha", ALPHA_);
         zipf_ = new org.apache.commons.math3.distribution.ZipfDistribution(maxDegree, ALPHA_);
         for (int i = 0; i < numSamples; ++i) {

--- a/src/main/java/ldbc/snb/datagen/generator/generators/PersonGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/PersonGenerator.java
@@ -40,9 +40,9 @@ import ldbc.snb.datagen.dictionary.Dictionaries;
 import ldbc.snb.datagen.entities.dynamic.person.Person;
 import ldbc.snb.datagen.generator.distribution.DegreeDistribution;
 import ldbc.snb.datagen.generator.tools.PowerDistribution;
+import ldbc.snb.datagen.util.Config;
 import ldbc.snb.datagen.util.RandomGeneratorFarm;
 import ldbc.snb.datagen.vocabulary.SN;
-import org.apache.hadoop.conf.Configuration;
 
 import java.text.Normalizer;
 import java.util.GregorianCalendar;
@@ -55,7 +55,7 @@ public class PersonGenerator {
     private RandomGeneratorFarm randomFarm;
     private int nextId = 0;
 
-    public PersonGenerator(Configuration conf, String degreeDistribution) {
+    public PersonGenerator(Config conf, String degreeDistribution) {
         try {
             this.degreeDistribution = (DegreeDistribution) Class.forName(degreeDistribution).newInstance();
             this.degreeDistribution.initialize(conf);

--- a/src/main/java/ldbc/snb/datagen/generator/generators/knowsgenerators/BterKnowsGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/knowsgenerators/BterKnowsGenerator.java
@@ -37,8 +37,8 @@ package ldbc.snb.datagen.generator.generators.knowsgenerators;
 
 import ldbc.snb.datagen.entities.dynamic.person.Person;
 import ldbc.snb.datagen.entities.dynamic.relations.Knows;
+import ldbc.snb.datagen.util.Config;
 import org.apache.commons.math3.util.Pair;
-import org.apache.hadoop.conf.Configuration;
 import org.roaringbitmap.RoaringBitmap;
 
 import java.io.BufferedReader;
@@ -58,7 +58,7 @@ public class BterKnowsGenerator implements KnowsGenerator {
 
     private int graphSize = 0;
     private Random random;
-    private Configuration conf;
+    private Config conf;
     private long[] expectedDegree;
     private double[] p;
     private Map<Long, RoaringBitmap> openCommunities = new HashMap<>();
@@ -257,7 +257,7 @@ public class BterKnowsGenerator implements KnowsGenerator {
     }
 
     @Override
-    public void initialize(Configuration conf) {
+    public void initialize(Config conf) {
         this.conf = conf;
     }
 }

--- a/src/main/java/ldbc/snb/datagen/generator/generators/knowsgenerators/ClusteringKnowsGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/knowsgenerators/ClusteringKnowsGenerator.java
@@ -39,7 +39,7 @@ import ldbc.snb.datagen.entities.dynamic.person.Person;
 import ldbc.snb.datagen.entities.dynamic.relations.Knows;
 import ldbc.snb.datagen.generator.tools.GraphUtils;
 import ldbc.snb.datagen.generator.tools.PersonGraph;
-import org.apache.hadoop.conf.Configuration;
+import ldbc.snb.datagen.util.Config;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -667,7 +667,7 @@ public class ClusteringKnowsGenerator implements KnowsGenerator {
         printStatistics();
     }
 
-    public void initialize(Configuration conf) {
+    public void initialize(Config conf) {
         targetCC = conf.getFloat("ldbc.snb.datagen.generator.generators.knowsgenerators.ClusteringKnowsGenerator.clusteringCoefficient", 0.1f);
         System.out.println("Initialized clustering coefficient to " + targetCC);
         targetCC /= 2.0f;

--- a/src/main/java/ldbc/snb/datagen/generator/generators/knowsgenerators/DistanceKnowsGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/knowsgenerators/DistanceKnowsGenerator.java
@@ -38,8 +38,8 @@ package ldbc.snb.datagen.generator.generators.knowsgenerators;
 import ldbc.snb.datagen.DatagenParams;
 import ldbc.snb.datagen.entities.dynamic.person.Person;
 import ldbc.snb.datagen.entities.dynamic.relations.Knows;
+import ldbc.snb.datagen.util.Config;
 import ldbc.snb.datagen.util.RandomGeneratorFarm;
-import org.apache.hadoop.conf.Configuration;
 
 import java.util.List;
 
@@ -65,7 +65,7 @@ public class DistanceKnowsGenerator implements KnowsGenerator {
     }
 
     @Override
-    public void initialize(Configuration conf) {
+    public void initialize(Config conf) {
         // This is inherited from knows generator and no initialization is required.
     }
 

--- a/src/main/java/ldbc/snb/datagen/generator/generators/knowsgenerators/KnowsGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/knowsgenerators/KnowsGenerator.java
@@ -36,12 +36,12 @@
 package ldbc.snb.datagen.generator.generators.knowsgenerators;
 
 import ldbc.snb.datagen.entities.dynamic.person.Person;
-import org.apache.hadoop.conf.Configuration;
+import ldbc.snb.datagen.util.Config;
 
 import java.util.List;
 
 public interface KnowsGenerator {
     void generateKnows(List<Person> persons, int seed, List<Float> percentages, int step_index);
 
-    void initialize(Configuration conf);
+    void initialize(Config conf);
 }

--- a/src/main/java/ldbc/snb/datagen/generator/generators/knowsgenerators/RandomKnowsGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/knowsgenerators/RandomKnowsGenerator.java
@@ -37,7 +37,7 @@ package ldbc.snb.datagen.generator.generators.knowsgenerators;
 
 import ldbc.snb.datagen.entities.dynamic.person.Person;
 import ldbc.snb.datagen.entities.dynamic.relations.Knows;
-import org.apache.hadoop.conf.Configuration;
+import ldbc.snb.datagen.util.Config;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -84,7 +84,7 @@ public class RandomKnowsGenerator implements KnowsGenerator {
     }
 
     @Override
-    public void initialize(Configuration conf) {
+    public void initialize(Config conf) {
         // Method inherited from Knows Generator. This specialization is empty because it does not require initizalization
     }
 }

--- a/src/main/java/ldbc/snb/datagen/hadoop/HadoopConfiguration.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/HadoopConfiguration.java
@@ -1,0 +1,45 @@
+package ldbc.snb.datagen.hadoop;
+
+import ldbc.snb.datagen.util.Config;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+
+
+public class HadoopConfiguration {
+
+    public static Config extractLdbcConfig(Configuration hadoop) {
+        return new Config(hadoop.getValByRegex("^(ldbc.snb.datagen).*$"));
+    }
+
+    public static void mergeLdbcIntoHadoop(Config config, Configuration hadoop) {
+        for (Map.Entry<String, String> entry : config.map.entrySet()) {
+            hadoop.set(entry.getKey(), entry.getValue());
+        }
+    }
+
+    public static Configuration prepare(Map<String, String> conf) throws IOException {
+        Configuration hadoopConf = new Configuration();
+
+        if (hadoopConf.get("fs.defaultFS").compareTo("file:///") == 0) {
+            System.out.println("Running in standalone mode. Setting numThreads to 1");
+            conf.put("ldbc.snb.datagen.generator.numThreads", "1");
+        }
+
+        conf.put("ldbc.snb.datagen.serializer.hadoopDir", conf.get("ldbc.snb.datagen.serializer.outputDir") + "/hadoop");
+        conf.put("ldbc.snb.datagen.serializer.socialNetworkDir", conf.get("ldbc.snb.datagen.serializer.outputDir") + "/social_network");
+
+        mergeLdbcIntoHadoop(new Config(conf), hadoopConf);
+        FileSystem dfs = FileSystem.get(hadoopConf);
+
+        dfs.delete(new Path(conf.get("ldbc.snb.datagen.serializer.hadoopDir")), true);
+        dfs.delete(new Path(conf.get("ldbc.snb.datagen.serializer.socialNetworkDir")), true);
+        FileUtils.deleteDirectory(new File(conf.get("ldbc.snb.datagen.serializer.outputDir") + "/substitution_parameters"));
+        return hadoopConf;
+    }
+}

--- a/src/main/java/ldbc/snb/datagen/hadoop/HadoopConfiguration.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/HadoopConfiguration.java
@@ -1,6 +1,7 @@
 package ldbc.snb.datagen.hadoop;
 
 import ldbc.snb.datagen.util.Config;
+import ldbc.snb.datagen.util.ConfigParser;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -33,6 +34,8 @@ public class HadoopConfiguration {
 
         conf.put("ldbc.snb.datagen.serializer.hadoopDir", conf.get("ldbc.snb.datagen.serializer.outputDir") + "/hadoop");
         conf.put("ldbc.snb.datagen.serializer.socialNetworkDir", conf.get("ldbc.snb.datagen.serializer.outputDir") + "/social_network");
+
+        ConfigParser.printConfig(conf);
 
         mergeLdbcIntoHadoop(new Config(conf), hadoopConf);
         FileSystem dfs = FileSystem.get(hadoopConf);

--- a/src/main/java/ldbc/snb/datagen/hadoop/generator/HadoopPersonActivityGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/generator/HadoopPersonActivityGenerator.java
@@ -36,13 +36,13 @@
 package ldbc.snb.datagen.hadoop.generator;
 
 import ldbc.snb.datagen.DatagenParams;
-import ldbc.snb.datagen.LdbcDatagen;
 import ldbc.snb.datagen.dictionary.Dictionaries;
 import ldbc.snb.datagen.entities.dynamic.person.Person;
 import ldbc.snb.datagen.entities.dynamic.relations.Knows;
 import ldbc.snb.datagen.generator.generators.PersonActivityGenerator;
 import ldbc.snb.datagen.hadoop.HadoopBlockMapper;
 import ldbc.snb.datagen.hadoop.HadoopBlockPartitioner;
+import ldbc.snb.datagen.hadoop.LdbcDatagen;
 import ldbc.snb.datagen.hadoop.key.TupleKey;
 import ldbc.snb.datagen.hadoop.key.blockkey.BlockKey;
 import ldbc.snb.datagen.hadoop.key.blockkey.BlockKeyComparator;

--- a/src/main/java/ldbc/snb/datagen/hadoop/miscjob/HadoopFileRanker.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/miscjob/HadoopFileRanker.java
@@ -35,7 +35,7 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
 package ldbc.snb.datagen.hadoop.miscjob;
 
-import ldbc.snb.datagen.LdbcDatagen;
+import ldbc.snb.datagen.hadoop.LdbcDatagen;
 import ldbc.snb.datagen.hadoop.key.TupleKey;
 import ldbc.snb.datagen.hadoop.key.blockkey.BlockKey;
 import ldbc.snb.datagen.hadoop.key.blockkey.BlockKeyComparator;

--- a/src/main/java/ldbc/snb/datagen/hadoop/miscjob/HadoopMergeFriendshipFiles.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/miscjob/HadoopMergeFriendshipFiles.java
@@ -35,7 +35,7 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
 package ldbc.snb.datagen.hadoop.miscjob;
 
-import ldbc.snb.datagen.LdbcDatagen;
+import ldbc.snb.datagen.hadoop.LdbcDatagen;
 import ldbc.snb.datagen.entities.dynamic.person.Person;
 import ldbc.snb.datagen.entities.dynamic.relations.Knows;
 import ldbc.snb.datagen.hadoop.HadoopBlockMapper;

--- a/src/main/java/ldbc/snb/datagen/hadoop/serializer/HadoopPersonSerializer.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/serializer/HadoopPersonSerializer.java
@@ -36,12 +36,12 @@
 package ldbc.snb.datagen.hadoop.serializer;
 
 import ldbc.snb.datagen.DatagenParams;
-import ldbc.snb.datagen.LdbcDatagen;
 import ldbc.snb.datagen.dictionary.Dictionaries;
 import ldbc.snb.datagen.entities.dynamic.person.Person;
 import ldbc.snb.datagen.entities.dynamic.relations.Knows;
 import ldbc.snb.datagen.hadoop.HadoopBlockMapper;
 import ldbc.snb.datagen.hadoop.HadoopTuplePartitioner;
+import ldbc.snb.datagen.hadoop.LdbcDatagen;
 import ldbc.snb.datagen.hadoop.key.TupleKey;
 import ldbc.snb.datagen.serializer.DynamicPersonSerializer;
 import ldbc.snb.datagen.serializer.InsertEventSerializer;

--- a/src/main/java/ldbc/snb/datagen/hadoop/serializer/HadoopPersonSortAndSerializer.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/serializer/HadoopPersonSortAndSerializer.java
@@ -36,13 +36,13 @@
 package ldbc.snb.datagen.hadoop.serializer;
 
 import ldbc.snb.datagen.DatagenParams;
-import ldbc.snb.datagen.LdbcDatagen;
 import ldbc.snb.datagen.dictionary.Dictionaries;
 import ldbc.snb.datagen.entities.dynamic.person.Person;
 import ldbc.snb.datagen.entities.dynamic.relations.Knows;
 import ldbc.snb.datagen.hadoop.HadoopBlockMapper;
 import ldbc.snb.datagen.hadoop.HadoopBlockPartitioner;
 import ldbc.snb.datagen.hadoop.HadoopTuplePartitioner;
+import ldbc.snb.datagen.hadoop.LdbcDatagen;
 import ldbc.snb.datagen.hadoop.key.TupleKey;
 import ldbc.snb.datagen.hadoop.key.blockkey.BlockKey;
 import ldbc.snb.datagen.hadoop.key.blockkey.BlockKeyComparator;

--- a/src/main/java/ldbc/snb/datagen/hadoop/serializer/HadoopStaticSerializer.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/serializer/HadoopStaticSerializer.java
@@ -36,12 +36,12 @@
 package ldbc.snb.datagen.hadoop.serializer;
 
 import ldbc.snb.datagen.DatagenParams;
-import ldbc.snb.datagen.LdbcDatagen;
 import ldbc.snb.datagen.dictionary.Dictionaries;
 import ldbc.snb.datagen.entities.statictype.Organisation;
 import ldbc.snb.datagen.entities.statictype.TagClass;
 import ldbc.snb.datagen.entities.statictype.place.Place;
 import ldbc.snb.datagen.entities.statictype.tag.Tag;
+import ldbc.snb.datagen.hadoop.LdbcDatagen;
 import ldbc.snb.datagen.serializer.StaticSerializer;
 import ldbc.snb.datagen.util.StringUtils;
 import org.apache.hadoop.conf.Configuration;

--- a/src/main/java/ldbc/snb/datagen/util/Config.java
+++ b/src/main/java/ldbc/snb/datagen/util/Config.java
@@ -1,0 +1,86 @@
+package ldbc.snb.datagen.util;
+
+import org.apache.hadoop.util.StringUtils;
+
+import java.util.Iterator;
+import java.util.Map;
+
+public class Config implements Iterable<Map.Entry<String, String>> {
+    public final Map<String, String> map;
+
+    public Config(Map<String, String> map) {
+        this.map = map;
+    }
+
+    public String get(String key) {
+        return map.get(key);
+    }
+
+    public String get(String key, String defaultValue) {
+        return map.getOrDefault(key, defaultValue);
+    }
+
+    public boolean getBoolean(String key, boolean defaultValue) {
+        String valueString = this.getTrimmed(key);
+        if (null != valueString && !valueString.isEmpty()) {
+            if (org.apache.hadoop.util.StringUtils.equalsIgnoreCase("true", valueString)) {
+                return true;
+            } else {
+                return StringUtils.equalsIgnoreCase("false", valueString) ? false : defaultValue;
+            }
+        } else {
+            return defaultValue;
+        }
+    }
+
+    public int getInt(String name, int defaultValue) {
+        String valueString = this.getTrimmed(name);
+        if (valueString == null) {
+            return defaultValue;
+        } else {
+            String hexString = this.getHexDigits(valueString);
+            return hexString != null ? Integer.parseInt(hexString, 16) : Integer.parseInt(valueString);
+        }
+    }
+
+    public double getDouble(String name, double defaultValue) {
+        String valueString = this.getTrimmed(name);
+        return valueString == null ? defaultValue : Double.parseDouble(valueString);
+    }
+
+    public float getFloat(String name, float defaultValue) {
+        String valueString = this.getTrimmed(name);
+        return valueString == null ? defaultValue : Float.parseFloat(valueString);
+    }
+
+    private String getHexDigits(String value) {
+        boolean negative = false;
+        String str = value;
+        String hexString = null;
+        if (value.startsWith("-")) {
+            negative = true;
+            str = value.substring(1);
+        }
+
+        if (!str.startsWith("0x") && !str.startsWith("0X")) {
+            return null;
+        } else {
+            hexString = str.substring(2);
+            if (negative) {
+                hexString = "-" + hexString;
+            }
+
+            return hexString;
+        }
+    }
+
+    public String getTrimmed(String name) {
+        String value = this.get(name);
+        return null == value ? null : value.trim();
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, String>> iterator() {
+        return this.map.entrySet().iterator();
+    }
+}

--- a/src/main/java/ldbc/snb/datagen/util/ConfigParser.java
+++ b/src/main/java/ldbc/snb/datagen/util/ConfigParser.java
@@ -35,133 +35,49 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
 package ldbc.snb.datagen.util;
 
-import ldbc.snb.datagen.LdbcDatagen;
-import org.apache.hadoop.conf.Configuration;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.TreeMap;
 
 public class ConfigParser {
 
-    private static TreeMap<String, ScaleFactor> scaleFactors;
-    private static final String SCALE_FACTORS_FILE = "scale_factors.xml";
-
-    public static Configuration initialize() throws Exception {
-
-        /** Default Parameters **/
-        Configuration conf = new Configuration();
-        conf.set("", Integer.toString(1));
-        conf.set("ldbc.snb.datagen.generator.numPersons", "10000");
-        conf.set("ldbc.snb.datagen.generator.startYear", "2010");
-        conf.set("ldbc.snb.datagen.generator.numYears", "3");
-        conf.set("ldbc.snb.datagen.generator.numThreads", Integer.toString(1));
-        conf.set("ldbc.snb.datagen.serializer.dynamicActivitySerializer", "ldbc.snb.datagen.serializer.snb.csv.dynamicserializer.activity.CsvBasicDynamicActivitySerializer");
-        conf.set("ldbc.snb.datagen.serializer.dynamicPersonSerializer", "ldbc.snb.datagen.serializer.snb.csv.dynamicserializer.person.CsvBasicDynamicPersonSerializer");
-        conf.set("ldbc.snb.datagen.serializer.staticSerializer", "ldbc.snb.datagen.serializer.snb.csv.staticserializer.CsvBasicStaticSerializer");
-        conf.set("ldbc.snb.datagen.generator.distribution.degreeDistribution", "ldbc.snb.datagen.generator.distribution.FacebookDegreeDistribution");
-        conf.set("ldbc.snb.datagen.generator.knowsGenerator", "ldbc.snb.datagen.generator.generators.knowsgenerators.DistanceKnowsGenerator");
-        conf.set("ldbc.snb.datagen.serializer.compressed", Boolean.toString(false));
-        conf.set("ldbc.snb.datagen.serializer.updateStreams", Boolean.toString(true));
-        conf.set("ldbc.snb.datagen.serializer.numPartitions", "1");
-        conf.set("ldbc.snb.datagen.serializer.numUpdatePartitions", "1");
-        conf.set("ldbc.snb.datagen.serializer.outputDir", "./");
-        conf.set("ldbc.snb.datagen.serializer.socialNetworkDir", "./social_network");
-        conf.set("ldbc.snb.datagen.serializer.hadoopDir", "./hadoop");
-        conf.set("ldbc.snb.datagen.serializer.endlineSeparator", Boolean.toString(false));
-        conf.set("ldbc.snb.datagen.generator.deltaTime", "10000");
-        conf.set("ldbc.snb.datagen.generator.activity", "true");
-        conf.set("ldbc.snb.datagen.serializer.dateFormatter", "ldbc.snb.datagen.util.formatter.StringDateFormatter");
-        conf.set("ldbc.snb.datagen.util.formatter.StringDateFormatter.dateTimeFormat", "yyyy-MM-dd'T'HH:mm:ss.SSS+00:00");
-        conf.set("ldbc.snb.datagen.util.formatter.StringDateFormatter.dateFormat", "yyyy-MM-dd");
-        conf.set("ldbc.snb.datagen.generator.person.similarity", "ldbc.snb.datagen.entities.dynamic.person.similarity.GeoDistanceSimilarity");
-        conf.set("ldbc.snb.datagen.parametergenerator.python", "python");
-        conf.set("ldbc.snb.datagen.parametergenerator.parameters", "true");
-        conf.set("ldbc.snb.datagen.serializer.persons.sort", "true");
-        conf.set("ldbc.snb.datagen.runsort","true");
-        /** Loading predefined Scale Factors **/
-
+    public static Map<String, String> readConfig(String paramsFile) {
+        Map<String, String> conf = new HashMap<>();
         try {
-            scaleFactors = new TreeMap<>();
-            DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
-            DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
-            Document doc = dBuilder.parse(LdbcDatagen.class.getResourceAsStream("/" + SCALE_FACTORS_FILE));
-            doc.getDocumentElement().normalize();
-
-            System.out.println("Reading scale factors..");
-            NodeList nodes = doc.getElementsByTagName("scale_factor");
-            for (int i = 0; i < nodes.getLength(); i++) {
-                Node node = nodes.item(i);
-                if (node.getNodeType() == Node.ELEMENT_NODE) {
-                    Element element = (Element) node;
-                    String scaleFactorName = element.getAttribute("name");
-                    ScaleFactor scaleFactor = new ScaleFactor();
-                    NodeList properties = ((Element) node).getElementsByTagName("property");
-                    for (int j = 0; j < properties.getLength(); ++j) {
-                        Element property = (Element) properties.item(j);
-                        String name = property.getElementsByTagName("name").item(0).getTextContent();
-                        String value = property.getElementsByTagName("value").item(0).getTextContent();
-                        scaleFactor.properties.put(name, value);
-                    }
-                    System.out.println("Available scale factor configuration set " + scaleFactorName);
-                    scaleFactors.put(scaleFactorName, scaleFactor);
-                }
-            }
-            System.out.println("Number of scale factors read " + scaleFactors.size());
-        } catch (ParserConfigurationException e) {
-            throw e;
-        } catch (IOException e) {
-            throw e;
-        }
-        return conf;
-    }
-
-    public static Configuration readConfig(Configuration conf, String paramsFile) {
-        try {
-            readConfig(conf, new FileInputStream(paramsFile));
+            readConfig(new FileInputStream(paramsFile));
         } catch (FileNotFoundException e) {
             throw new RuntimeException(e);
         }
         return conf;
     }
 
-    public static Configuration readConfig(Configuration conf, InputStream paramStream) {
+    public static Map<String, String> readConfig(InputStream paramStream) {
+        Map<String, String> conf = new HashMap<>();
         try {
+            ScaleFactors scaleFactors = ScaleFactors.INSTANCE;
             Properties properties = new Properties();
-            properties.load(new InputStreamReader(paramStream, "UTF-8"));
+            properties.load(new InputStreamReader(paramStream, StandardCharsets.UTF_8));
             String val = (String) properties.get("ldbc.snb.datagen.generator.scaleFactor");
             if (val != null) {
-                if (!scaleFactors.containsKey(val)) {
+                if (!scaleFactors.value.containsKey(val)) {
                     throw new IllegalArgumentException("Scale factor " + val + " does not exist");
                 }
-                ScaleFactor scaleFactor = scaleFactors.get(val);
+                ScaleFactor scaleFactor = scaleFactors.value.get(val);
                 System.out.println("Applied configuration of scale factor " + val);
                 for (Map.Entry<String, String> e : scaleFactor.properties.entrySet()) {
-                    conf.set(e.getKey(), e.getValue());
+                    conf.put(e.getKey(), e.getValue());
                 }
             }
 
             for (String s : properties.stringPropertyNames()) {
                 if (s.compareTo("ldbc.snb.datagen.generator.scaleFactor") != 0) {
-                    conf.set(s, properties.getProperty(s));
+                    conf.put(s, properties.getProperty(s));
                 }
-            }
-
-            if (conf.get("fs.defaultFS").compareTo("file:///") == 0) {
-                System.out.println("Running in standalone mode. Setting numThreads to 1");
-                conf.set("ldbc.snb.datagen.generator.numThreads", "1");
             }
         } catch (Exception e) {
             System.err.println(e.getMessage());
@@ -170,13 +86,42 @@ public class ConfigParser {
         return conf;
     }
 
-
-    public static void printConfig(Configuration conf) {
+    public static void printConfig(HashMap<String, String> conf) {
         System.out.println("********* Configuration *********");
-        Map<String, String> map = conf.getValByRegex("^(ldbc.snb.datagen).*$");
-        for (Map.Entry<String, String> e : map.entrySet()) {
-            System.out.println(e.getKey() + " " + e.getValue());
-        }
+        conf.forEach((key, value) -> System.out.println(key + " " + value));
         System.out.println("*********************************");
+    }
+
+    public static Map<String, String> defaultConfiguration() {
+        Map<String, String> conf = new HashMap<>();
+        conf.put("", Integer.toString(1));
+        conf.put("ldbc.snb.datagen.generator.numPersons", "10000");
+        conf.put("ldbc.snb.datagen.generator.startYear", "2010");
+        conf.put("ldbc.snb.datagen.generator.numYears", "3");
+        conf.put("ldbc.snb.datagen.generator.numThreads", Integer.toString(1));
+        conf.put("ldbc.snb.datagen.serializer.dynamicActivitySerializer", "ldbc.snb.datagen.serializer.snb.csv.dynamicserializer.activity.CsvBasicDynamicActivitySerializer");
+        conf.put("ldbc.snb.datagen.serializer.dynamicPersonSerializer", "ldbc.snb.datagen.serializer.snb.csv.dynamicserializer.person.CsvBasicDynamicPersonSerializer");
+        conf.put("ldbc.snb.datagen.serializer.staticSerializer", "ldbc.snb.datagen.serializer.snb.csv.staticserializer.CsvBasicStaticSerializer");
+        conf.put("ldbc.snb.datagen.generator.distribution.degreeDistribution", "ldbc.snb.datagen.generator.distribution.FacebookDegreeDistribution");
+        conf.put("ldbc.snb.datagen.generator.knowsGenerator", "ldbc.snb.datagen.generator.generators.knowsgenerators.DistanceKnowsGenerator");
+        conf.put("ldbc.snb.datagen.serializer.compressed", Boolean.toString(false));
+        conf.put("ldbc.snb.datagen.serializer.updateStreams", Boolean.toString(true));
+        conf.put("ldbc.snb.datagen.serializer.numPartitions", "1");
+        conf.put("ldbc.snb.datagen.serializer.numUpdatePartitions", "1");
+        conf.put("ldbc.snb.datagen.serializer.outputDir", "./");
+        conf.put("ldbc.snb.datagen.serializer.socialNetworkDir", "./social_network");
+        conf.put("ldbc.snb.datagen.serializer.hadoopDir", "./hadoop");
+        conf.put("ldbc.snb.datagen.serializer.endlineSeparator", Boolean.toString(false));
+        conf.put("ldbc.snb.datagen.generator.deltaTime", "10000");
+        conf.put("ldbc.snb.datagen.generator.activity", "true");
+        conf.put("ldbc.snb.datagen.serializer.dateFormatter", "ldbc.snb.datagen.util.formatter.StringDateFormatter");
+        conf.put("ldbc.snb.datagen.util.formatter.StringDateFormatter.dateTimeFormat", "yyyy-MM-dd'T'HH:mm:ss.SSS+00:00");
+        conf.put("ldbc.snb.datagen.util.formatter.StringDateFormatter.dateFormat", "yyyy-MM-dd");
+        conf.put("ldbc.snb.datagen.generator.person.similarity", "ldbc.snb.datagen.entities.dynamic.person.similarity.GeoDistanceSimilarity");
+        conf.put("ldbc.snb.datagen.parametergenerator.python", "python");
+        conf.put("ldbc.snb.datagen.parametergenerator.parameters", "true");
+        conf.put("ldbc.snb.datagen.serializer.persons.sort", "true");
+        conf.put("ldbc.snb.datagen.runsort","true");
+        return conf;
     }
 }

--- a/src/main/java/ldbc/snb/datagen/util/ConfigParser.java
+++ b/src/main/java/ldbc/snb/datagen/util/ConfigParser.java
@@ -47,13 +47,11 @@ import java.util.Properties;
 public class ConfigParser {
 
     public static Map<String, String> readConfig(String paramsFile) {
-        Map<String, String> conf = new HashMap<>();
         try {
-            readConfig(new FileInputStream(paramsFile));
+            return readConfig(new FileInputStream(paramsFile));
         } catch (FileNotFoundException e) {
             throw new RuntimeException(e);
         }
-        return conf;
     }
 
     public static Map<String, String> readConfig(InputStream paramStream) {

--- a/src/main/java/ldbc/snb/datagen/util/ConfigParser.java
+++ b/src/main/java/ldbc/snb/datagen/util/ConfigParser.java
@@ -86,7 +86,7 @@ public class ConfigParser {
         return conf;
     }
 
-    public static void printConfig(HashMap<String, String> conf) {
+    public static void printConfig(Map<String, String> conf) {
         System.out.println("********* Configuration *********");
         conf.forEach((key, value) -> System.out.println(key + ": " + value));
         System.out.println("*********************************");

--- a/src/main/java/ldbc/snb/datagen/util/DateUtils.java
+++ b/src/main/java/ldbc/snb/datagen/util/DateUtils.java
@@ -39,7 +39,6 @@ import ldbc.snb.datagen.DatagenParams;
 import ldbc.snb.datagen.entities.dynamic.person.Person;
 import ldbc.snb.datagen.generator.tools.PowerDistribution;
 import ldbc.snb.datagen.util.formatter.DateFormatter;
-import org.apache.hadoop.conf.Configuration;
 
 import java.util.Arrays;
 import java.util.Calendar;
@@ -67,7 +66,7 @@ public class DateUtils {
     private DateFormatter dateFormatter;
 
     // This constructor is for the case of friendship's created date generator
-    public DateUtils(Configuration conf, GregorianCalendar simulationStartYear, GregorianCalendar simulationEndYear,
+    public DateUtils(Config conf, GregorianCalendar simulationStartYear, GregorianCalendar simulationEndYear,
                      double alpha) {
         simulationEndYear.setTimeZone(TimeZone.getTimeZone("GMT"));
         simulationStartYear.setTimeZone(TimeZone.getTimeZone("GMT"));

--- a/src/main/java/ldbc/snb/datagen/util/ScaleFactors.java
+++ b/src/main/java/ldbc/snb/datagen/util/ScaleFactors.java
@@ -1,0 +1,55 @@
+package ldbc.snb.datagen.util;
+
+import ldbc.snb.datagen.hadoop.LdbcDatagen;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.util.TreeMap;
+
+public class ScaleFactors {
+
+    public final TreeMap<String, ScaleFactor> value;
+
+    public static final String SCALE_FACTORS_FILE = "scale_factors.xml";
+    public static final ScaleFactors INSTANCE = new ScaleFactors();
+
+    private ScaleFactors() {
+        try {
+            value = new TreeMap<>();
+            DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+            DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+            Document doc = dBuilder.parse(LdbcDatagen.class.getResourceAsStream("/" + SCALE_FACTORS_FILE));
+            doc.getDocumentElement().normalize();
+
+            System.out.println("Reading scale factors..");
+            NodeList nodes = doc.getElementsByTagName("scale_factor");
+            for (int i = 0; i < nodes.getLength(); i++) {
+                Node node = nodes.item(i);
+                if (node.getNodeType() == Node.ELEMENT_NODE) {
+                    Element element = (Element) node;
+                    String scaleFactorName = element.getAttribute("name");
+                    ScaleFactor scaleFactor = new ScaleFactor();
+                    NodeList properties = ((Element) node).getElementsByTagName("property");
+                    for (int j = 0; j < properties.getLength(); ++j) {
+                        Element property = (Element) properties.item(j);
+                        String name = property.getElementsByTagName("name").item(0).getTextContent();
+                        String value = property.getElementsByTagName("value").item(0).getTextContent();
+                        scaleFactor.properties.put(name, value);
+                    }
+                    System.out.println("Available scale factor configuration set " + scaleFactorName);
+                    value.put(scaleFactorName, scaleFactor);
+                }
+            }
+            System.out.println("Number of scale factors read " + value.size());
+        } catch (ParserConfigurationException | IOException | SAXException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/ldbc/snb/datagen/util/formatter/DateFormatter.java
+++ b/src/main/java/ldbc/snb/datagen/util/formatter/DateFormatter.java
@@ -35,10 +35,10 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
 package ldbc.snb.datagen.util.formatter;
 
-import org.apache.hadoop.conf.Configuration;
+import ldbc.snb.datagen.util.Config;
 
 public interface DateFormatter {
-    void initialize(Configuration config);
+    void initialize(Config config);
 
     String formatDate(long date);
 

--- a/src/main/java/ldbc/snb/datagen/util/formatter/LongDateFormatter.java
+++ b/src/main/java/ldbc/snb/datagen/util/formatter/LongDateFormatter.java
@@ -35,7 +35,8 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
 package ldbc.snb.datagen.util.formatter;
 
-import org.apache.hadoop.conf.Configuration;
+
+import ldbc.snb.datagen.util.Config;
 
 import java.util.Calendar;
 import java.util.GregorianCalendar;
@@ -48,7 +49,7 @@ public class LongDateFormatter implements DateFormatter {
     private int minSecond;
     private int minMillisecond;
 
-    public void initialize(Configuration config) {
+    public void initialize(Config config) {
         calendar_ = new GregorianCalendar(TimeZone.getTimeZone("GMT"));
         minHour = calendar_.getActualMinimum(Calendar.HOUR);
         minMinute = calendar_.getActualMinimum(Calendar.MINUTE);

--- a/src/main/java/ldbc/snb/datagen/util/formatter/StringDateFormatter.java
+++ b/src/main/java/ldbc/snb/datagen/util/formatter/StringDateFormatter.java
@@ -35,7 +35,7 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
 package ldbc.snb.datagen.util.formatter;
 
-import org.apache.hadoop.conf.Configuration;
+import ldbc.snb.datagen.util.Config;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -50,7 +50,7 @@ public class StringDateFormatter implements DateFormatter {
     private SimpleDateFormat gmtDateFormatter_;
     private Date date_;
 
-    public void initialize(Configuration conf) {
+    public void initialize(Config conf) {
 
         formatDateTimeString_ = conf
                 .get("ldbc.snb.datagen.util.formatter.StringDateFormatter.dateTimeFormat", formatDateTimeString_);

--- a/src/test/java/ldbc/snb/datagen/test/LdbcDatagenTest.java
+++ b/src/test/java/ldbc/snb/datagen/test/LdbcDatagenTest.java
@@ -1,6 +1,7 @@
 package ldbc.snb.datagen.test;
 
-import ldbc.snb.datagen.LdbcDatagen;
+import ldbc.snb.datagen.hadoop.HadoopConfiguration;
+import ldbc.snb.datagen.hadoop.LdbcDatagen;
 import ldbc.snb.datagen.dictionary.Dictionaries;
 import ldbc.snb.datagen.test.csv.ColumnSet;
 import ldbc.snb.datagen.test.csv.ExistsCheck;
@@ -22,6 +23,7 @@ import org.junit.Test;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -32,14 +34,14 @@ public class LdbcDatagenTest {
 
     @BeforeClass
     public static void generateData() throws Exception {
-        Configuration conf = ConfigParser.initialize();
-        ConfigParser.readConfig(conf, "./test_params.ini");
-        ConfigParser.readConfig(conf, LdbcDatagen.class.getResourceAsStream("/params_default.ini"));
+        Map<String, String> confMap = ConfigParser.defaultConfiguration();
+        confMap.putAll(ConfigParser.readConfig("./test_params.ini"));
+        confMap.putAll(ConfigParser.readConfig(LdbcDatagen.class.getResourceAsStream("/params_default.ini")));
         try {
-            LdbcDatagen.prepareConfiguration(conf);
-            LdbcDatagen.initializeContext(conf);
+            Configuration hadoopConf = HadoopConfiguration.prepare(confMap);
+            LdbcDatagen.initializeContext(hadoopConf);
             LdbcDatagen datagen = new LdbcDatagen();
-            datagen.runGenerateJob(conf);
+            datagen.runGenerateJob(hadoopConf);
         } catch (Exception e) {
             throw e;
         }

--- a/src/test/java/ldbc/snb/datagen/test/dictionaries/PlaceDictionaryTest.java
+++ b/src/test/java/ldbc/snb/datagen/test/dictionaries/PlaceDictionaryTest.java
@@ -1,12 +1,14 @@
 package ldbc.snb.datagen.test.dictionaries;
 
-import ldbc.snb.datagen.LdbcDatagen;
+import ldbc.snb.datagen.hadoop.HadoopConfiguration;
+import ldbc.snb.datagen.hadoop.LdbcDatagen;
 import ldbc.snb.datagen.dictionary.PlaceDictionary;
 import ldbc.snb.datagen.util.ConfigParser;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Random;
 
 import static org.junit.Assert.*;
@@ -17,11 +19,11 @@ public class PlaceDictionaryTest {
 
             PlaceDictionary placeDictionary = new PlaceDictionary();
         try {
-            Configuration conf = ConfigParser.initialize();
-            ConfigParser.readConfig(conf, "./test_params.ini");
-            ConfigParser.readConfig(conf, LdbcDatagen.class.getResourceAsStream("/params_default.ini"));
-            LdbcDatagen.prepareConfiguration(conf);
-            LdbcDatagen.initializeContext(conf);
+            Map<String, String> conf = ConfigParser.defaultConfiguration();
+            conf.putAll(ConfigParser.readConfig("./test_params.ini"));
+            conf.putAll(ConfigParser.readConfig(LdbcDatagen.class.getResourceAsStream("/params_default.ini")));
+            Configuration hadoopConf = HadoopConfiguration.prepare(conf);
+            LdbcDatagen.initializeContext(hadoopConf);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Spark is stuck on Hadoop 2.7, so it is better not to assume compatibility for avoiding headaches and instead remove `org.apache.hadoop` dependencies where not needed.

The project uses the `Configuration` data structure from Hadoop throughout the codebase, even for parts that are otherwise unrelated to Hadoop. This PR restricts its usage to Hadoop related code, and introduces a `Config` class as substitute. Unfortunately this means that some code from `Configuration`will be duplicated (mostly typed getters), but at least we make `dictionary`, `entities` and `generator` packages independent. Note that `serializer` is using Hadoop-related serialization code, so it doesn't make sense to involve in this refactor. This is undesirable as all Hadoop-related `serialization` code should reside in`hadoop.serializer` but that refactor is out of scope of this PR.

