### PR TITLE
Spark and Hadoop as provided dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,16 +25,19 @@
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
       <version>${scala.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_${scala.compat.version}</artifactId>
       <version>${spark.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.compat.version}</artifactId>
       <version>${spark.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,7 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-client</artifactId>
       <version>3.2.1</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>ca.umontreal.iro</groupId>

--- a/run.sh
+++ b/run.sh
@@ -45,10 +45,6 @@ fi
 mvn clean
 mvn -DskipTests assembly:assembly
 
-#if [ "$(uname)" == "Darwin" ]; then
-  #zip -d $LDBC_SNB_DATAGEN_HOME/target/ldbc_snb_datagen-0.4.0-SNAPSHOT-jar-with-dependencies.jar META-INF/LICENSE
-#fi
-
 $HADOOP_HOME/bin/hadoop jar $LDBC_SNB_DATAGEN_HOME/target/ldbc_snb_datagen-0.4.0-SNAPSHOT-jar-with-dependencies.jar $LDBC_SNB_DATAGEN_HOME/params.ini
 
 rm -f m*personFactors*

--- a/run.sh
+++ b/run.sh
@@ -45,9 +45,9 @@ fi
 mvn clean
 mvn -DskipTests assembly:assembly
 
-if [ "$(uname)" == "Darwin" ]; then
-  zip -d $LDBC_SNB_DATAGEN_HOME/target/ldbc_snb_datagen-0.4.0-SNAPSHOT-jar-with-dependencies.jar META-INF/LICENSE
-fi
+#if [ "$(uname)" == "Darwin" ]; then
+  #zip -d $LDBC_SNB_DATAGEN_HOME/target/ldbc_snb_datagen-0.4.0-SNAPSHOT-jar-with-dependencies.jar META-INF/LICENSE
+#fi
 
 $HADOOP_HOME/bin/hadoop jar $LDBC_SNB_DATAGEN_HOME/target/ldbc_snb_datagen-0.4.0-SNAPSHOT-jar-with-dependencies.jar $LDBC_SNB_DATAGEN_HOME/params.ini
 


### PR DESCRIPTION
Spark, Scala and Hadoop should be provided by the runtime and excluded from the artifact.

[Docs](https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html#dependency-scope)

This will resolve https://github.com/ldbc/ldbc_snb_datagen/issues/110
