### PR TITLE
fix reducers

### DIFF
--- a/src/main/java/ldbc/snb/datagen/hadoop/generator/HadoopKnowsGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/generator/HadoopKnowsGenerator.java
@@ -83,7 +83,8 @@ public class HadoopKnowsGenerator extends DatagenHadoopJob {
         private int numGeneratedEdges = 0;
         private Person.PersonSimilarity personSimilarity;
 
-        protected void setup(Context context) {
+        protected void setup(Context context) throws IOException, InterruptedException {
+            super.setup(context);
             this.hadoopConf = context.getConfiguration();
             try {
                 DatagenContext.initialize(conf);

--- a/src/main/java/ldbc/snb/datagen/hadoop/serializer/HadoopPersonSortAndSerializer.java
+++ b/src/main/java/ldbc/snb/datagen/hadoop/serializer/HadoopPersonSortAndSerializer.java
@@ -75,7 +75,8 @@ public class HadoopPersonSortAndSerializer extends DatagenHadoopJob {
         private AbstractDeleteEventSerializer abstractDeleteEventSerializer;
 
         @Override
-        protected void setup(Context context) {
+        protected void setup(Context context) throws IOException, InterruptedException {
+            super.setup(context);
             Configuration hadoopConf = context.getConfiguration();
             LdbcConfiguration conf = HadoopConfiguration.extractLdbcConfig(hadoopConf);
             int reducerId = context.getTaskAttemptID().getTaskID().getId();


### PR DESCRIPTION
I introduced a bug that causes `NullPointerExceptions` to occur in a distributed scenario, because the configuration was not properly initialized.

```
Error: java.lang.RuntimeException: java.lang.NullPointerException
	at ldbc.snb.datagen.DatagenParams.readConf(DatagenParams.java:339)
	at ldbc.snb.datagen.DatagenContext.initialize(DatagenContext.java:12)
	at ldbc.snb.datagen.hadoop.generator.HadoopKnowsGenerator$HadoopKnowsGeneratorReducer.setup(HadoopKnowsGenerator.java:88)
	at org.apache.hadoop.mapreduce.Reducer.run(Reducer.java:168)
	at org.apache.hadoop.mapred.ReduceTask.runNewReducer(ReduceTask.java:635)
	at org.apache.hadoop.mapred.ReduceTask.run(ReduceTask.java:390)
	at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:175)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:422)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1844)
	at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:169)
Caused by: java.lang.NullPointerException
	at ldbc.snb.datagen.DatagenParams.readConf(DatagenParams.java:255)
	... 10 more
```