### PR TITLE
Fix hasModerator edge by capturing its deletionDate in the Forum

### DIFF
--- a/src/main/java/ldbc/snb/datagen/entities/dynamic/Forum.java
+++ b/src/main/java/ldbc/snb/datagen/entities/dynamic/Forum.java
@@ -52,6 +52,7 @@ public class Forum implements DynamicActivity {
     private boolean isExplicitlyDeleted;
     private long id;
     private PersonSummary moderator;
+    private long moderatorDeletionDate;
     private long creationDate;
     private long deletionDate;
     private String title;
@@ -62,7 +63,7 @@ public class Forum implements DynamicActivity {
     private ForumType forumType;
 
 
-    public Forum(long id, long creationDate, long deletionDate, PersonSummary moderator, String title, int placeId, int language, ForumType forumType, boolean isExplicitlyDeleted) {
+    public Forum(long id, long creationDate, long deletionDate, PersonSummary moderator, long moderatorDeletionDate, String title, int placeId, int language, ForumType forumType, boolean isExplicitlyDeleted) {
         assert (moderator.getCreationDate() + DatagenParams.delta) <= creationDate : "Moderator's creation date is less than or equal to the Forum creation date";
         memberships = new ArrayList<>();
         tags = new ArrayList<>();
@@ -72,6 +73,7 @@ public class Forum implements DynamicActivity {
         this.title = title;
         this.placeId = placeId;
         this.moderator = new PersonSummary(moderator);
+        this.moderatorDeletionDate = moderatorDeletionDate;
         this.language = language;
         this.forumType = forumType;
         this.isExplicitlyDeleted = isExplicitlyDeleted;
@@ -99,6 +101,10 @@ public class Forum implements DynamicActivity {
 
     public PersonSummary getModerator() {
         return moderator;
+    }
+
+    public long getModeratorDeletionDate() {
+        return moderatorDeletionDate;
     }
 
     public long getCreationDate() {

--- a/src/main/java/ldbc/snb/datagen/generator/generators/ForumGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/ForumGenerator.java
@@ -76,6 +76,7 @@ public class ForumGenerator {
                 person.getCreationDate() + DatagenParams.delta,
                 person.getDeletionDate(),
                 new PersonSummary(person),
+                person.getDeletionDate(),
                 StringUtils.clampString("Wall of " + person.getFirstName() + " " + person.getLastName(), 256),
                 person.getCityId(),
                 language,
@@ -117,8 +118,6 @@ public class ForumGenerator {
         long groupMaxCreationDate = Math.min(moderator.getDeletionDate(), Dictionaries.dates.getSimulationEnd());
         long groupCreationDate = Dictionaries.dates.randomDate(randomFarm.get(RandomGeneratorFarm.Aspect.DATE), groupMinCreationDate, groupMaxCreationDate);
 
-        //TODO: Currently if the group moderator is deleted before the forum then no new moderator is installed. This breaks the schema.
-
         // deletion date
         long groupDeletionDate;
         boolean isExplicitlyDeleted;
@@ -131,6 +130,9 @@ public class ForumGenerator {
             isExplicitlyDeleted = false;
             groupDeletionDate = Dictionaries.dates.getNetworkCollapse();
         }
+
+        // the hasModerator edge is deleted if either the Forum (group) or the Person (moderator) is deleted
+        long moderatorDeletionDate = Math.min(groupDeletionDate, moderator.getDeletionDate());
 
         int language = randomFarm.get(RandomGeneratorFarm.Aspect.LANGUAGE).nextInt(moderator.getLanguages().size());
 
@@ -148,6 +150,7 @@ public class ForumGenerator {
                 groupCreationDate,
                 groupDeletionDate,
                 new PersonSummary(moderator),
+                moderatorDeletionDate,
                 StringUtils.clampString("Group for " + Dictionaries.tags.getName(interestId)
                         .replace("\"", "\\\"") + " in " + Dictionaries.places
                         .getPlaceName(moderator.getCityId()), 256),
@@ -276,6 +279,7 @@ public class ForumGenerator {
                 albumCreationDate,
                 albumDeletionDate,
                 new PersonSummary(person),
+                person.getDeletionDate(),
                 StringUtils.clampString("Album " + numAlbum + " of " + person.getFirstName() + " " + person
                         .getLastName(), 256),
                 person.getCityId(),


### PR DESCRIPTION
Fixes #133 by saving the `deletionDate` of the `hasModerator` edge in the `Forum` and only serializing these edges if they exist after the bulk load threshold and/or the generator is running in 'raw data' mode.

Also makes the required changes for the `CsvMergeForeignSerializer`, though I did not test this.

My main question is that other than being a bit hackish and involving some code duplication, is this approach a good for handling `hasModerator` edges?