### PR TITLE
Update Dockerfile and README with memory configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,19 @@ VOLUME /mnt/datagen.jar /mnt/params.ini /mnt/data
 
 WORKDIR /mnt/data
 
-ENTRYPOINT ["/spark/bin/spark-submit"]
+# adjust these environment variables
+ENV TEMP_DIR /tmp
+ENV EXECUTOR_MEMORY "1G"
+ENV DRIVER_MEMORY "5G"
 
-# memory settings are sufficient for SF10,
-# increase proportionally for larger scale factors
-CMD ["--class", "ldbc.snb.datagen.spark.LdbcDatagen", \
-     "--master", "local[*]", \
-     "--executor-memory", "1G", \
-     "--driver-memory", "5G", \
-     "/mnt/datagen.jar", \
-     "/mnt/params.ini" \
-]
+# the SPARK_* variables are used by submit.sh to configure the Spark job
+ENV SPARK_LOCAL_DIRS ${TEMP_DIR}
+ENV SPARK_SUBMIT_ARGS --executor-memory ${EXECUTOR_MEMORY} --driver-memory ${DRIVER_MEMORY}
+ENV SPARK_APPLICATION_MAIN_CLASS ldbc.snb.datagen.spark.LdbcDatagen
+ENV SPARK_MASTER_URL local[*]
+ENV SPARK_APPLICATION_JAR_LOCATION /mnt/datagen.jar
+ENV SPARK_APPLICATION_ARGS /mnt/params.ini
+
+COPY submit.sh /
+
+ENTRYPOINT ["/bin/bash", "/submit.sh"]

--- a/README.md
+++ b/README.md
@@ -83,3 +83,5 @@ The graph schema is as follows:
 ### Troubleshooting
 
 * When running the tests, they might throw a `java.net.UnknownHostException: your_hostname: your_hostname: Name or service not known` coming from `org.apache.hadoop.mapreduce.JobSubmitter.submitJobInternal`. The solution is to add an entry of your machine's hostname to the `/etc/hosts` file: `127.0.1.1 your_hostname`.
+* If you are using Docker and Spark runs out of space, make sure that there is enough free space in `/tmp` (or override it using the `TEMP_DIR` variable in the Dockerfile and rebuild the image) and also that Docker itself has enough space to store its containers.
+To move the location of the Docker containers to a larger disk, stop Docker, edit (or create) the `/etc/docker/daemon.json` file and add `{ "data-root": "/path/to/new/docker/data/dir" }`, then sync the old folder if needed, and restart Docker. (See [more detailed instructions](https://www.guguweb.com/2019/02/07/how-to-move-docker-data-directory-to-another-location-on-ubuntu/)).

--- a/submit.sh
+++ b/submit.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+export SPARK_HOME=/spark
+
+echo "Submit application ${SPARK_APPLICATION_JAR_LOCATION} with main class ${SPARK_APPLICATION_MAIN_CLASS} to Spark master ${SPARK_MASTER_URL}"
+echo "Passing arguments ${SPARK_APPLICATION_ARGS}"
+/spark/bin/spark-submit \
+    --class ${SPARK_APPLICATION_MAIN_CLASS} \
+    --master ${SPARK_MASTER_URL} \
+    ${SPARK_SUBMIT_ARGS} \
+    ${SPARK_APPLICATION_JAR_LOCATION} ${SPARK_APPLICATION_ARGS}


### PR DESCRIPTION
I added a shell script based on the one used in BDE Spark image.
This was necessary because Docker [doesn't substitute environment variables in `CMD`](https://stackoverflow.com/questions/40454470/how-can-i-use-a-variable-inside-a-dockerfile-cmd).