### PR TITLE
Generate interactive data without deletes

### DIFF
--- a/src/main/java/ldbc/snb/datagen/generator/generators/CommentGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/CommentGenerator.java
@@ -36,6 +36,7 @@
 package ldbc.snb.datagen.generator.generators;
 
 import com.google.common.collect.Streams;
+import ldbc.snb.datagen.DatagenMode;
 import ldbc.snb.datagen.DatagenParams;
 import ldbc.snb.datagen.dictionary.Dictionaries;
 import ldbc.snb.datagen.entities.dynamic.Forum;
@@ -136,19 +137,24 @@ public class CommentGenerator {
 
             long deletionDate;
             boolean isExplicitlyDeleted;
-
-            // if person is a deleter and selected for delete
-            if (membership.getPerson().getIsMessageDeleter() && randomFarm.get(RandomGeneratorFarm.Aspect.DELETION_COMM).nextDouble() < DatagenParams.probCommentDeleted) {
-                isExplicitlyDeleted = true;
-                long minDeletionDate = creationDate + DatagenParams.delta;
-                long maxDeletionDate = Collections.min(Arrays.asList(parentMessage.getDeletionDate(), membership.getDeletionDate(), Dictionaries.dates.getSimulationEnd()));
-                if (maxDeletionDate <= minDeletionDate) {
-                    return Iterators.ForIterator.CONTINUE();
-                }
-                deletionDate = Dictionaries.dates.powerLawDeleteDate(randomFarm.get(RandomGeneratorFarm.Aspect.DATE), minDeletionDate, maxDeletionDate);
-            } else {
+            if (DatagenParams.getDatagenMode() == DatagenMode.INTERACTIVE) {
+                deletionDate = Dictionaries.dates.getNetworkCollapse();
                 isExplicitlyDeleted = false;
-                deletionDate = Collections.min(Arrays.asList(parentMessage.getDeletionDate(), membership.getDeletionDate()));
+            } else {
+
+                // if person is a deleter and selected for delete
+                if (membership.getPerson().getIsMessageDeleter() && randomFarm.get(RandomGeneratorFarm.Aspect.DELETION_COMM).nextDouble() < DatagenParams.probCommentDeleted) {
+                    isExplicitlyDeleted = true;
+                    long minDeletionDate = creationDate + DatagenParams.delta;
+                    long maxDeletionDate = Collections.min(Arrays.asList(parentMessage.getDeletionDate(), membership.getDeletionDate(), Dictionaries.dates.getSimulationEnd()));
+                    if (maxDeletionDate <= minDeletionDate) {
+                        return Iterators.ForIterator.CONTINUE();
+                    }
+                    deletionDate = Dictionaries.dates.powerLawDeleteDate(randomFarm.get(RandomGeneratorFarm.Aspect.DATE), minDeletionDate, maxDeletionDate);
+                } else {
+                    isExplicitlyDeleted = false;
+                    deletionDate = Collections.min(Arrays.asList(parentMessage.getDeletionDate(), membership.getDeletionDate()));
+                }
             }
 
             int country = membership.getPerson().getCountryId();

--- a/src/main/java/ldbc/snb/datagen/generator/generators/ForumGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/ForumGenerator.java
@@ -36,6 +36,7 @@
 
 package ldbc.snb.datagen.generator.generators;
 
+import ldbc.snb.datagen.DatagenMode;
 import ldbc.snb.datagen.DatagenParams;
 import ldbc.snb.datagen.dictionary.Dictionaries;
 import ldbc.snb.datagen.entities.dynamic.Forum;
@@ -121,14 +122,19 @@ public class ForumGenerator {
         // deletion date
         long groupDeletionDate;
         boolean isExplicitlyDeleted;
-        if (randomFarm.get(RandomGeneratorFarm.Aspect.DELETION_FORUM).nextDouble() < DatagenParams.probForumDeleted) {
-            isExplicitlyDeleted = true;
-            long groupMinDeletionDate = groupCreationDate + DatagenParams.delta;
-            long groupMaxDeletionDate = Dictionaries.dates.getSimulationEnd();
-            groupDeletionDate = Dictionaries.dates.randomDate(randomFarm.get(RandomGeneratorFarm.Aspect.DATE), groupMinDeletionDate, groupMaxDeletionDate);
-        } else {
-            isExplicitlyDeleted = false;
+        if (DatagenParams.getDatagenMode() == DatagenMode.INTERACTIVE) {
             groupDeletionDate = Dictionaries.dates.getNetworkCollapse();
+            isExplicitlyDeleted = false;
+        } else {
+            if (randomFarm.get(RandomGeneratorFarm.Aspect.DELETION_FORUM).nextDouble() < DatagenParams.probForumDeleted) {
+                isExplicitlyDeleted = true;
+                long groupMinDeletionDate = groupCreationDate + DatagenParams.delta;
+                long groupMaxDeletionDate = Dictionaries.dates.getSimulationEnd();
+                groupDeletionDate = Dictionaries.dates.randomDate(randomFarm.get(RandomGeneratorFarm.Aspect.DATE), groupMinDeletionDate, groupMaxDeletionDate);
+            } else {
+                isExplicitlyDeleted = false;
+                groupDeletionDate = Dictionaries.dates.getNetworkCollapse();
+            }
         }
 
         // the hasModerator edge is deleted if either the Forum (group) or the Person (moderator) is deleted
@@ -187,17 +193,22 @@ public class ForumGenerator {
 
                         long hasMemberDeletionDate;
                         boolean isHasMemberExplicitlyDeleted;
-                        if (randomFarm.get(RandomGeneratorFarm.Aspect.DELETION_MEMB).nextDouble() < DatagenParams.probMembDeleted) {
-                            isHasMemberExplicitlyDeleted = true;
-                            long minDeletionDate = hasMemberCreationDate + DatagenParams.delta;
-                            long maxDeletionDate = Collections.min(Arrays.asList(knows.to().getDeletionDate(), forum.getDeletionDate(), Dictionaries.dates.getSimulationEnd()));
-                            if (maxDeletionDate - minDeletionDate < 0) {
-                                continue;
-                            }
-                            hasMemberDeletionDate = Dictionaries.dates.randomDate(random, minDeletionDate, maxDeletionDate);
-                        } else {
+                        if (DatagenParams.getDatagenMode() == DatagenMode.INTERACTIVE) {
+                            hasMemberDeletionDate = Dictionaries.dates.getNetworkCollapse();
                             isHasMemberExplicitlyDeleted = false;
-                            hasMemberDeletionDate = Collections.min(Arrays.asList(knows.to().getDeletionDate(), forum.getDeletionDate()));
+                        } else {
+                            if (randomFarm.get(RandomGeneratorFarm.Aspect.DELETION_MEMB).nextDouble() < DatagenParams.probMembDeleted) {
+                                isHasMemberExplicitlyDeleted = true;
+                                long minDeletionDate = hasMemberCreationDate + DatagenParams.delta;
+                                long maxDeletionDate = Collections.min(Arrays.asList(knows.to().getDeletionDate(), forum.getDeletionDate(), Dictionaries.dates.getSimulationEnd()));
+                                if (maxDeletionDate - minDeletionDate < 0) {
+                                    continue;
+                                }
+                                hasMemberDeletionDate = Dictionaries.dates.randomDate(random, minDeletionDate, maxDeletionDate);
+                            } else {
+                                isHasMemberExplicitlyDeleted = false;
+                                hasMemberDeletionDate = Collections.min(Arrays.asList(knows.to().getDeletionDate(), forum.getDeletionDate()));
+                            }
                         }
                         ForumMembership hasMember = new ForumMembership(forum.getId(), hasMemberCreationDate, hasMemberDeletionDate, knows.to(), Forum.ForumType.GROUP, isHasMemberExplicitlyDeleted);
                         forum.addMember(hasMember);
@@ -221,17 +232,22 @@ public class ForumGenerator {
 
                         long hasMemberDeletionDate;
                         boolean isHasMemberExplicitlyDeleted;
-                        if (randomFarm.get(RandomGeneratorFarm.Aspect.DELETION_MEMB).nextDouble() < DatagenParams.probMembDeleted) {
-                            isHasMemberExplicitlyDeleted = true;
-                            long minHasMemberDeletionDate = hasMemberCreationDate + DatagenParams.delta;
-                            long maxHasMemberDeletionDate = Collections.min(Arrays.asList(member.getDeletionDate(), forum.getDeletionDate(), Dictionaries.dates.getSimulationEnd()));
-                            if (maxHasMemberCreationDate - minHasMemberDeletionDate < 0) {
-                                continue;
-                            }
-                            hasMemberDeletionDate = Dictionaries.dates.randomDate(random, minHasMemberDeletionDate, maxHasMemberDeletionDate);
-                        } else {
+                        if (DatagenParams.getDatagenMode() == DatagenMode.INTERACTIVE) {
+                            hasMemberDeletionDate = Dictionaries.dates.getNetworkCollapse();
                             isHasMemberExplicitlyDeleted = false;
-                            hasMemberDeletionDate = Collections.min(Arrays.asList(member.getDeletionDate(), forum.getDeletionDate()));
+                        } else {
+                            if (randomFarm.get(RandomGeneratorFarm.Aspect.DELETION_MEMB).nextDouble() < DatagenParams.probMembDeleted) {
+                                isHasMemberExplicitlyDeleted = true;
+                                long minHasMemberDeletionDate = hasMemberCreationDate + DatagenParams.delta;
+                                long maxHasMemberDeletionDate = Collections.min(Arrays.asList(member.getDeletionDate(), forum.getDeletionDate(), Dictionaries.dates.getSimulationEnd()));
+                                if (maxHasMemberCreationDate - minHasMemberDeletionDate < 0) {
+                                    continue;
+                                }
+                                hasMemberDeletionDate = Dictionaries.dates.randomDate(random, minHasMemberDeletionDate, maxHasMemberDeletionDate);
+                            } else {
+                                isHasMemberExplicitlyDeleted = false;
+                                hasMemberDeletionDate = Collections.min(Arrays.asList(member.getDeletionDate(), forum.getDeletionDate()));
+                            }
                         }
                         forum.addMember(new ForumMembership(forum.getId(), hasMemberCreationDate, hasMemberDeletionDate, new PersonSummary(member), Forum.ForumType.GROUP, isHasMemberExplicitlyDeleted));
                         groupMembers.add(member.getAccountId());
@@ -260,17 +276,22 @@ public class ForumGenerator {
 
         long albumDeletionDate;
         boolean isExplicitlyDeleted;
-        if (randomFarm.get(RandomGeneratorFarm.Aspect.DELETION_FORUM).nextDouble() < DatagenParams.probForumDeleted) {
-            isExplicitlyDeleted = true;
-            long minAlbumDeletionDate = albumCreationDate + DatagenParams.delta;
-            long maxAlbumDeletionDate = Math.min(person.getDeletionDate(), Dictionaries.dates.getSimulationEnd());
-            if (maxAlbumDeletionDate - minAlbumCreationDate < 0){
-                return null;
-            }
-            albumDeletionDate = Dictionaries.dates.randomDate(randomFarm.get(RandomGeneratorFarm.Aspect.DATE), minAlbumDeletionDate, maxAlbumDeletionDate);
-        } else {
+        if (DatagenParams.getDatagenMode() == DatagenMode.INTERACTIVE) {
+            albumDeletionDate = Dictionaries.dates.getNetworkCollapse();
             isExplicitlyDeleted = false;
-            albumDeletionDate = person.getDeletionDate();
+        } else {
+            if (randomFarm.get(RandomGeneratorFarm.Aspect.DELETION_FORUM).nextDouble() < DatagenParams.probForumDeleted) {
+                isExplicitlyDeleted = true;
+                long minAlbumDeletionDate = albumCreationDate + DatagenParams.delta;
+                long maxAlbumDeletionDate = Math.min(person.getDeletionDate(), Dictionaries.dates.getSimulationEnd());
+                if (maxAlbumDeletionDate - minAlbumCreationDate < 0) {
+                    return null;
+                }
+                albumDeletionDate = Dictionaries.dates.randomDate(randomFarm.get(RandomGeneratorFarm.Aspect.DATE), minAlbumDeletionDate, maxAlbumDeletionDate);
+            } else {
+                isExplicitlyDeleted = false;
+                albumDeletionDate = person.getDeletionDate();
+            }
         }
 
 

--- a/src/main/java/ldbc/snb/datagen/generator/generators/LikeGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/LikeGenerator.java
@@ -36,6 +36,7 @@
 package ldbc.snb.datagen.generator.generators;
 
 import com.google.common.collect.Streams;
+import ldbc.snb.datagen.DatagenMode;
 import ldbc.snb.datagen.DatagenParams;
 import ldbc.snb.datagen.dictionary.Dictionaries;
 import ldbc.snb.datagen.entities.dynamic.Forum;
@@ -87,22 +88,27 @@ public class LikeGenerator {
 
             long likeDeletionDate;
             boolean isExplicitlyDeleted;
-            if (membership.getPerson().getIsMessageDeleter() && randomDeleteLike.nextDouble() < DatagenParams.probLikeDeleted) {
-                isExplicitlyDeleted = true;
-                long minDeletionDate = likeCreationDate + DatagenParams.delta;
-                long maxDeletionDate = Collections.min(Arrays.asList(
-                        membership.getPerson().getDeletionDate(),
-                        message.getDeletionDate(),
-                        Dictionaries.dates.getSimulationEnd()));
-                if (maxDeletionDate <= minDeletionDate) {
-                    return Iterators.ForIterator.CONTINUE();
-                }
-                likeDeletionDate = Dictionaries.dates.powerLawDeleteDate(random, minDeletionDate, maxDeletionDate);
-            } else {
+            if (DatagenParams.getDatagenMode() == DatagenMode.INTERACTIVE) {
+                likeDeletionDate = Dictionaries.dates.getNetworkCollapse();
                 isExplicitlyDeleted = false;
-                likeDeletionDate = Collections.min(Arrays.asList(
-                        membership.getPerson().getDeletionDate(),
-                        message.getDeletionDate()));
+            } else {
+                if (membership.getPerson().getIsMessageDeleter() && randomDeleteLike.nextDouble() < DatagenParams.probLikeDeleted) {
+                    isExplicitlyDeleted = true;
+                    long minDeletionDate = likeCreationDate + DatagenParams.delta;
+                    long maxDeletionDate = Collections.min(Arrays.asList(
+                            membership.getPerson().getDeletionDate(),
+                            message.getDeletionDate(),
+                            Dictionaries.dates.getSimulationEnd()));
+                    if (maxDeletionDate <= minDeletionDate) {
+                        return Iterators.ForIterator.CONTINUE();
+                    }
+                    likeDeletionDate = Dictionaries.dates.powerLawDeleteDate(random, minDeletionDate, maxDeletionDate);
+                } else {
+                    isExplicitlyDeleted = false;
+                    likeDeletionDate = Collections.min(Arrays.asList(
+                            membership.getPerson().getDeletionDate(),
+                            message.getDeletionDate()));
+                }
             }
 
             like.setExplicitlyDeleted(isExplicitlyDeleted);

--- a/src/main/java/ldbc/snb/datagen/generator/generators/PersonGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/PersonGenerator.java
@@ -35,6 +35,7 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
 package ldbc.snb.datagen.generator.generators;
 
+import ldbc.snb.datagen.DatagenMode;
 import ldbc.snb.datagen.DatagenParams;
 import ldbc.snb.datagen.dictionary.Dictionaries;
 import ldbc.snb.datagen.entities.dynamic.person.Person;
@@ -102,16 +103,23 @@ public class PersonGenerator {
 
         long maxKnows = Math.min(degreeDistribution.nextDegree(), DatagenParams.maxNumFriends);
         person.setMaxNumKnows(maxKnows);
-        boolean delete = personDeleteDistribution.isDeleted(randomFarm.get(RandomGeneratorFarm.Aspect.DELETION_PERSON),maxKnows);
+
+
         long deletionDate;
-        if (delete) {
-            person.setExplicitlyDeleted(true);
-            long maxDeletionDate = Dictionaries.dates.getSimulationEnd();
-            deletionDate = Dictionaries.dates.randomPersonDeletionDate(
-                    randomFarm.get(RandomGeneratorFarm.Aspect.DATE), creationDate, person.getMaxNumKnows(), maxDeletionDate);
-        } else {
-            person.setExplicitlyDeleted(false);
+        if (DatagenParams.getDatagenMode() == DatagenMode.INTERACTIVE) {
             deletionDate = Dictionaries.dates.getNetworkCollapse();
+            person.setExplicitlyDeleted(false);
+        } else {
+            boolean delete = personDeleteDistribution.isDeleted(randomFarm.get(RandomGeneratorFarm.Aspect.DELETION_PERSON), maxKnows);
+            if (delete) {
+                person.setExplicitlyDeleted(true);
+                long maxDeletionDate = Dictionaries.dates.getSimulationEnd();
+                deletionDate = Dictionaries.dates.randomPersonDeletionDate(
+                        randomFarm.get(RandomGeneratorFarm.Aspect.DATE), creationDate, person.getMaxNumKnows(), maxDeletionDate);
+            } else {
+                person.setExplicitlyDeleted(false);
+                deletionDate = Dictionaries.dates.getNetworkCollapse();
+            }
         }
         person.setDeletionDate(deletionDate);
 

--- a/src/main/java/ldbc/snb/datagen/generator/generators/PhotoGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/PhotoGenerator.java
@@ -36,6 +36,7 @@
 package ldbc.snb.datagen.generator.generators;
 
 import com.google.common.collect.Streams;
+import ldbc.snb.datagen.DatagenMode;
 import ldbc.snb.datagen.DatagenParams;
 import ldbc.snb.datagen.dictionary.Dictionaries;
 import ldbc.snb.datagen.entities.dynamic.Forum;
@@ -91,14 +92,19 @@ class PhotoGenerator {
 
             long deletionDate;
             boolean isExplicitlyDeleted;
-            if (album.getModerator().getIsMessageDeleter() &&  randomDeletePost.nextDouble() < DatagenParams.probPhotoDeleted) {
-                isExplicitlyDeleted = true;
-                long minDeletionDate = creationDate + DatagenParams.delta;
-                long maxDeletionDate = Math.min(album.getDeletionDate(), Dictionaries.dates.getSimulationEnd());
-                deletionDate = Dictionaries.dates.powerLawDeleteDate(randomDate, minDeletionDate, maxDeletionDate);
-            } else {
+            if (DatagenParams.getDatagenMode() == DatagenMode.INTERACTIVE) {
+                deletionDate = Dictionaries.dates.getNetworkCollapse();
                 isExplicitlyDeleted = false;
-                deletionDate = album.getDeletionDate();
+            } else {
+                if (album.getModerator().getIsMessageDeleter() && randomDeletePost.nextDouble() < DatagenParams.probPhotoDeleted) {
+                    isExplicitlyDeleted = true;
+                    long minDeletionDate = creationDate + DatagenParams.delta;
+                    long maxDeletionDate = Math.min(album.getDeletionDate(), Dictionaries.dates.getSimulationEnd());
+                    deletionDate = Dictionaries.dates.powerLawDeleteDate(randomDate, minDeletionDate, maxDeletionDate);
+                } else {
+                    isExplicitlyDeleted = false;
+                    deletionDate = album.getDeletionDate();
+                }
             }
 
             int country = album.getModerator().getCountryId();

--- a/src/main/java/ldbc/snb/datagen/generator/generators/postgenerators/FlashmobPostGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/postgenerators/FlashmobPostGenerator.java
@@ -35,6 +35,7 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
 package ldbc.snb.datagen.generator.generators.postgenerators;
 
+import ldbc.snb.datagen.DatagenMode;
 import ldbc.snb.datagen.DatagenParams;
 import ldbc.snb.datagen.dictionary.Dictionaries;
 import ldbc.snb.datagen.entities.dynamic.Forum;
@@ -190,17 +191,22 @@ public class FlashmobPostGenerator extends PostGenerator {
 
         // add deletion date
         long postDeletionDate;
-        if (membership.getPerson().getIsMessageDeleter() && randomDeletePost.nextDouble() < DatagenParams.postMapping[numComments]) {
-            postCore.setExplicitlyDeleted(true);
-            long minDeletionDate = creationDate + DatagenParams.delta;
-            long maxDeletionDate = Math.min(membership.getDeletionDate(), Dictionaries.dates.getSimulationEnd());
-            if (maxDeletionDate - minDeletionDate < 0) {
-                return null;
-            }
-            postDeletionDate = Dictionaries.dates.powerLawDeleteDate(randomDate, minDeletionDate, maxDeletionDate);
-        } else {
+        if (DatagenParams.getDatagenMode() == DatagenMode.INTERACTIVE) {
+            postDeletionDate = Dictionaries.dates.getNetworkCollapse();
             postCore.setExplicitlyDeleted(false);
-            postDeletionDate = Math.min(membership.getDeletionDate(), Dictionaries.dates.getSimulationEnd());
+        } else {
+            if (membership.getPerson().getIsMessageDeleter() && randomDeletePost.nextDouble() < DatagenParams.postMapping[numComments]) {
+                postCore.setExplicitlyDeleted(true);
+                long minDeletionDate = creationDate + DatagenParams.delta;
+                long maxDeletionDate = Math.min(membership.getDeletionDate(), Dictionaries.dates.getSimulationEnd());
+                if (maxDeletionDate - minDeletionDate < 0) {
+                    return null;
+                }
+                postDeletionDate = Dictionaries.dates.powerLawDeleteDate(randomDate, minDeletionDate, maxDeletionDate);
+            } else {
+                postCore.setExplicitlyDeleted(false);
+                postDeletionDate = Math.min(membership.getDeletionDate(), Dictionaries.dates.getSimulationEnd());
+            }
         }
         postCore.setDeletionDate(postDeletionDate);
 

--- a/src/main/java/ldbc/snb/datagen/generator/generators/postgenerators/UniformPostGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/postgenerators/UniformPostGenerator.java
@@ -35,6 +35,7 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
 package ldbc.snb.datagen.generator.generators.postgenerators;
 
+import ldbc.snb.datagen.DatagenMode;
 import ldbc.snb.datagen.DatagenParams;
 import ldbc.snb.datagen.dictionary.Dictionaries;
 import ldbc.snb.datagen.entities.dynamic.Forum;
@@ -67,19 +68,24 @@ public class UniformPostGenerator extends PostGenerator {
 
         // add deletion date
         long postDeletionDate;
-        if (membership.getPerson().getIsMessageDeleter() && randomDeletePost.nextDouble() < DatagenParams.postMapping[numComments]) {
+        if (DatagenParams.getDatagenMode() == DatagenMode.INTERACTIVE) {
+            postDeletionDate = Dictionaries.dates.getNetworkCollapse();
+            postCore.setExplicitlyDeleted(false);
+        } else {
+            if (membership.getPerson().getIsMessageDeleter() && randomDeletePost.nextDouble() < DatagenParams.postMapping[numComments]) {
 
                 postCore.setExplicitlyDeleted(true);
-            long minDeletionDate = postCreationDate + DatagenParams.delta;
-            long maxDeletionDate = Math.min(membership.getDeletionDate(), Dictionaries.dates.getSimulationEnd());
+                long minDeletionDate = postCreationDate + DatagenParams.delta;
+                long maxDeletionDate = Math.min(membership.getDeletionDate(), Dictionaries.dates.getSimulationEnd());
 
-            if (maxDeletionDate - minDeletionDate < 0) {
-                return null;
+                if (maxDeletionDate - minDeletionDate < 0) {
+                    return null;
+                }
+                postDeletionDate = Dictionaries.dates.powerLawDeleteDate(randomDate, minDeletionDate, maxDeletionDate);
+            } else {
+                postCore.setExplicitlyDeleted(false);
+                postDeletionDate = Math.min(membership.getDeletionDate(), Dictionaries.dates.getSimulationEnd());
             }
-            postDeletionDate = Dictionaries.dates.powerLawDeleteDate(randomDate, minDeletionDate, maxDeletionDate);
-        } else {
-            postCore.setExplicitlyDeleted(false);
-            postDeletionDate = Math.min(membership.getDeletionDate(), Dictionaries.dates.getSimulationEnd());
         }
 
         postCore.setDeletionDate(postDeletionDate);


### PR DESCRIPTION
If ran in `interactive` mode datagen should not generate any delete events, hence should not generate delete operations. To achieve this behaviour, if the datagen mode is set to `interactive` the deletion date field is set to network collapse when entities are generated. This should produce a slightly larger data set than previously, as no longer do entities with creation and deletion dates before the bulk load cut off fall into the "skip" serialisation category, see page 39 of the spec. 

This brings datagen inline with the design in #176 