### PR TITLE
Get rid of guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
     <scala.compat.version>2.11</scala.compat.version>
     <spark.version>2.4.5</spark.version>
     <spec2.version>4.2.0</spec2.version>
-    <guava.version>25.1-jre</guava.version>
   </properties>
 
   <dependencies>
@@ -44,11 +43,6 @@
       <groupId>com.github.scopt</groupId>
       <artifactId>scopt_${scala.compat.version}</artifactId>
       <version>3.7.1</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
     </dependency>
     <dependency>
       <groupId>org.javatuples</groupId>

--- a/src/main/java/ldbc/snb/datagen/entities/dynamic/person/IP.java
+++ b/src/main/java/ldbc/snb/datagen/entities/dynamic/person/IP.java
@@ -51,6 +51,18 @@ public final class IP implements Writable, Serializable, Cloneable {
     public static final int BYTE2_SHIFT_POSITION = 16;
     public static final int BYTE3_SHIFT_POSITION = 8;
 
+    public void setIp(int ip) {
+        this.ip = ip;
+    }
+
+    public void setMask(int mask) {
+        this.mask = mask;
+    }
+
+    public void setNetwork(int network) {
+        this.network = network;
+    }
+
     private int ip;
     private int mask;
     private int network;

--- a/src/main/java/ldbc/snb/datagen/generator/generators/CommentGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/CommentGenerator.java
@@ -35,7 +35,6 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
 package ldbc.snb.datagen.generator.generators;
 
-import com.google.common.collect.Streams;
 import ldbc.snb.datagen.DatagenMode;
 import ldbc.snb.datagen.DatagenParams;
 import ldbc.snb.datagen.dictionary.Dictionaries;
@@ -50,6 +49,7 @@ import ldbc.snb.datagen.generator.generators.textgenerators.TextGenerator;
 import ldbc.snb.datagen.util.Iterators;
 import ldbc.snb.datagen.util.PersonBehavior;
 import ldbc.snb.datagen.util.RandomGeneratorFarm;
+import ldbc.snb.datagen.util.Streams;
 import ldbc.snb.datagen.vocabulary.SN;
 import org.javatuples.Pair;
 

--- a/src/main/java/ldbc/snb/datagen/generator/generators/LikeGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/LikeGenerator.java
@@ -35,7 +35,6 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
 package ldbc.snb.datagen.generator.generators;
 
-import com.google.common.collect.Streams;
 import ldbc.snb.datagen.DatagenMode;
 import ldbc.snb.datagen.DatagenParams;
 import ldbc.snb.datagen.dictionary.Dictionaries;
@@ -46,7 +45,7 @@ import ldbc.snb.datagen.entities.dynamic.relations.Like;
 import ldbc.snb.datagen.entities.dynamic.relations.Like.LikeType;
 import ldbc.snb.datagen.generator.tools.PowerDistribution;
 import ldbc.snb.datagen.util.Iterators;
-import ldbc.snb.datagen.util.RandomGeneratorFarm;
+import ldbc.snb.datagen.util.Streams;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/src/main/java/ldbc/snb/datagen/generator/generators/PersonActivityGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/PersonActivityGenerator.java
@@ -36,8 +36,6 @@
 
 package ldbc.snb.datagen.generator.generators;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Streams;
 import ldbc.snb.datagen.DatagenParams;
 import ldbc.snb.datagen.dictionary.Dictionaries;
 import ldbc.snb.datagen.entities.dynamic.Forum;
@@ -52,10 +50,10 @@ import ldbc.snb.datagen.generator.generators.postgenerators.FlashmobPostGenerato
 import ldbc.snb.datagen.generator.generators.postgenerators.UniformPostGenerator;
 import ldbc.snb.datagen.generator.generators.textgenerators.LdbcSnbTextGenerator;
 import ldbc.snb.datagen.generator.generators.textgenerators.TextGenerator;
-import ldbc.snb.datagen.serializer.PersonActivityExporter;
 import ldbc.snb.datagen.util.FactorTable;
 import ldbc.snb.datagen.util.Iterators;
 import ldbc.snb.datagen.util.RandomGeneratorFarm;
+import ldbc.snb.datagen.util.Streams;
 import org.javatuples.Pair;
 import org.javatuples.Triplet;
 
@@ -64,7 +62,6 @@ import java.io.OutputStream;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 public class PersonActivityGenerator {
 

--- a/src/main/java/ldbc/snb/datagen/generator/generators/PhotoGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/PhotoGenerator.java
@@ -35,7 +35,6 @@
  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.*/
 package ldbc.snb.datagen.generator.generators;
 
-import com.google.common.collect.Streams;
 import ldbc.snb.datagen.DatagenMode;
 import ldbc.snb.datagen.DatagenParams;
 import ldbc.snb.datagen.dictionary.Dictionaries;
@@ -46,6 +45,7 @@ import ldbc.snb.datagen.entities.dynamic.relations.Like;
 import ldbc.snb.datagen.util.Iterators;
 import ldbc.snb.datagen.util.PersonBehavior;
 import ldbc.snb.datagen.util.RandomGeneratorFarm;
+import ldbc.snb.datagen.util.Streams;
 import ldbc.snb.datagen.vocabulary.SN;
 import org.javatuples.Pair;
 

--- a/src/main/java/ldbc/snb/datagen/generator/generators/postgenerators/PostGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/postgenerators/PostGenerator.java
@@ -36,8 +36,6 @@
 
 package ldbc.snb.datagen.generator.generators.postgenerators;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Streams;
 import ldbc.snb.datagen.DatagenParams;
 import ldbc.snb.datagen.dictionary.Dictionaries;
 import ldbc.snb.datagen.entities.dynamic.Forum;
@@ -52,6 +50,7 @@ import ldbc.snb.datagen.generator.generators.textgenerators.TextGenerator;
 import ldbc.snb.datagen.util.Iterators;
 import ldbc.snb.datagen.util.PersonBehavior;
 import ldbc.snb.datagen.util.RandomGeneratorFarm;
+import ldbc.snb.datagen.util.Streams;
 import ldbc.snb.datagen.vocabulary.SN;
 import org.javatuples.Pair;
 import org.javatuples.Triplet;

--- a/src/main/java/ldbc/snb/datagen/util/Streams.java
+++ b/src/main/java/ldbc/snb/datagen/util/Streams.java
@@ -1,0 +1,17 @@
+package ldbc.snb.datagen.util;
+
+import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class Streams {
+
+    public static <T> Stream<T> stream(Iterator<T> sourceIterator) {
+        return StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(sourceIterator, Spliterator.ORDERED),
+                false);
+
+    }
+}

--- a/src/test/java/ldbc/snb/datagen/util/IteratorsTest.java
+++ b/src/test/java/ldbc/snb/datagen/util/IteratorsTest.java
@@ -1,6 +1,5 @@
 package ldbc.snb.datagen.util;
 
-import com.google.common.collect.Streams;
 import ldbc.snb.datagen.util.functional.Function;
 import org.junit.Test;
 


### PR DESCRIPTION
Spark has a shadowed version of guava 14 bundled, but let's get rid of it anyways to make the dependency setup cleaner.