### PR TITLE
Fix datetime format 

### DIFF
--- a/src/main/scala/ldbc/snb/datagen/SparkApp.scala
+++ b/src/main/scala/ldbc/snb/datagen/SparkApp.scala
@@ -1,5 +1,6 @@
 package ldbc.snb.datagen
 
+import ldbc.snb.datagen.syntax._
 import org.apache.spark.sql.SparkSession
 
 trait SparkApp {
@@ -8,6 +9,14 @@ trait SparkApp {
   implicit def spark = SparkSession
     .builder()
     .appName(appName)
+    .pipe(applySparkConf(defaultSparkConf))
     .getOrCreate()
+
+  private def applySparkConf(sparkConf: Map[String, String])(builder: SparkSession.Builder) =
+    sparkConf.foldLeft(builder) { case (b, (k, v)) => b.config(k, v) }
+
+  def defaultSparkConf: Map[String, String] = Map(
+    "spark.sql.session.timeZone" -> "GMT"
+  )
 
 }

--- a/src/main/scala/ldbc/snb/datagen/transformation/io/GraphWriter.scala
+++ b/src/main/scala/ldbc/snb/datagen/transformation/io/GraphWriter.scala
@@ -23,7 +23,9 @@ object GraphWriter {
 class WriterFormatOptions(val format: String, mode: Mode, private val customFormatOptions: Map[String, String] = Map.empty) {
   val defaultCsvFormatOptions = Map(
     "header" -> "true",
-    "sep" ->  "|"
+    "sep" ->  "|",
+    "dateFormat" -> Raw.datePattern,
+    "timestampFormat" -> Raw.dateTimePattern
   )
 
   val forcedRawCsvFormatOptions = Map(

--- a/src/main/scala/ldbc/snb/datagen/transformation/model/package.scala
+++ b/src/main/scala/ldbc/snb/datagen/transformation/model/package.scala
@@ -82,7 +82,7 @@ package object model {
         $"explicitlyDeleted".as("explicitlyDeleted")
       ) ++ cols)
 
-      def dateTimePattern = "yyyy-MM-dd'T'HH:mm:ss.SSS+00:00"
+      def dateTimePattern = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZ"
       def datePattern = "yyyy-MM-dd"
 
     }


### PR DESCRIPTION
Closes #291
- Force GMT time zone.
- Fix the date time format to adhere to spec https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html
- Use default