### PR TITLE
Change header attribute names

### DIFF
--- a/src/main/java/ldbc/snb/datagen/serializer/DynamicActivitySerializer.java
+++ b/src/main/java/ldbc/snb/datagen/serializer/DynamicActivitySerializer.java
@@ -61,14 +61,14 @@ public class DynamicActivitySerializer extends LdbcSerializer {
 
         List<String> dates2 = ImmutableList.of("creationDate", "deletionDate");
 
-        writers.get(FORUM)                    .writeHeader(dates1, ImmutableList.of("id", "title", "moderator"));
+        writers.get(FORUM)                    .writeHeader(dates1, ImmutableList.of("id", "title", "ModeratorPerson.id"));
         writers.get(FORUM_HASTAG_TAG)         .writeHeader(dates2, ImmutableList.of("Forum.id", "Tag.id"));
         writers.get(FORUM_HASMEMBER_PERSON)   .writeHeader(dates1, ImmutableList.of("Forum.id", "Person.id"));
 
-        writers.get(POST)                     .writeHeader(dates1, ImmutableList.of("id", "imageFile", "locationIP", "browserUsed", "language", "content", "length", "creator", "Forum.id", "Country.id"));
+        writers.get(POST)                     .writeHeader(dates1, ImmutableList.of("id", "imageFile", "locationIP", "browserUsed", "language", "content", "length", "CreatorPerson.id", "ContainerForum.id", "LocationCountry.id"));
         writers.get(POST_HASTAG_TAG)          .writeHeader(dates2, ImmutableList.of("Post.id", "Tag.id"));
 
-        writers.get(COMMENT)                  .writeHeader(dates1, ImmutableList.of("id", "locationIP", "browserUsed", "content", "length", "creator", "Country.id", "replyOfPost", "replyOfComment"));
+        writers.get(COMMENT)                  .writeHeader(dates1, ImmutableList.of("id", "locationIP", "browserUsed", "content", "length", "CreatorPerson.id", "LocationCountry.id", "ParentPost.id", "ParentComment.id"));
         writers.get(COMMENT_HASTAG_TAG)       .writeHeader(dates2, ImmutableList.of("Comment.id", "Tag.id"));
 
         writers.get(PERSON_LIKES_POST)        .writeHeader(dates1, ImmutableList.of("Person.id", "Post.id"));
@@ -79,7 +79,7 @@ public class DynamicActivitySerializer extends LdbcSerializer {
     public void serialize(final Forum forum) {
         List<String> dates = ImmutableList.of(formatDateTime(forum.getCreationDate()), formatDateTime(forum.getDeletionDate()), String.valueOf(forum.isExplicitlyDeleted()));
 
-        // creationDate, deletionDate, explicitlyDeleted, id, title, moderator
+        // creationDate, deletionDate, explicitlyDeleted, id, title, ModeratorPerson.id
         writers.get(FORUM).writeEntry(dates, ImmutableList.of(
                 Long.toString(forum.getId()),
                 forum.getTitle(),
@@ -88,7 +88,7 @@ public class DynamicActivitySerializer extends LdbcSerializer {
 
         List<String> dates2 = ImmutableList.of(formatDateTime(forum.getCreationDate()), formatDateTime(forum.getDeletionDate()));
         for (Integer i : forum.getTags()) {
-            // creationDate, deletionDate Forum.id, Tag.id
+            // creationDate, deletionDate, Forum.id, Tag.id
             writers.get(FORUM_HASTAG_TAG).writeEntry(dates2, ImmutableList.of(
                     Long.toString(forum.getId()),
                     Integer.toString(i)
@@ -100,7 +100,7 @@ public class DynamicActivitySerializer extends LdbcSerializer {
     public void serialize(final Post post) {
         List<String> dates1 = ImmutableList.of(formatDateTime(post.getCreationDate()), formatDateTime(post.getDeletionDate()), String.valueOf(post.isExplicitlyDeleted()));
 
-        // creationDate, deletionDate, explicitlyDeleted, id, imageFile, locationIP, browserUsed, language, content, length, creator, Forum.id, place
+        // creationDate, deletionDate, explicitlyDeleted, id, imageFile, locationIP, browserUsed, language, content, length, CreatorPerson.id, ContainerForum.id, LocationCountry.id
         writers.get(POST).writeEntry(dates1, ImmutableList.of(
                 Long.toString(post.getMessageId()),
                 "",
@@ -117,7 +117,7 @@ public class DynamicActivitySerializer extends LdbcSerializer {
         List<String> dates2 = ImmutableList.of(formatDateTime(post.getCreationDate()), formatDateTime(post.getDeletionDate()));
 
         for (Integer t : post.getTags()) {
-            // creationDate, deletionDate Post.id, Tag.id
+            // creationDate, deletionDate, Post.id, Tag.id
             writers.get(POST_HASTAG_TAG).writeEntry(dates2, ImmutableList.of(
                     Long.toString(post.getMessageId()),
                     Integer.toString(t)
@@ -128,7 +128,7 @@ public class DynamicActivitySerializer extends LdbcSerializer {
     public void serialize(final Comment comment) {
         List<String> dates1 = ImmutableList.of(formatDateTime(comment.getCreationDate()), formatDateTime(comment.getDeletionDate()), String.valueOf(comment.isExplicitlyDeleted()));
 
-        // creationDate, deletionDate, explicitlyDeleted, id, locationIP, browserUsed, content, length, creator, place, parentPost, parentComment
+        // creationDate, deletionDate, explicitlyDeleted, id, locationIP, browserUsed, content, length, CreatorPerson.id, LocationCountry.id, ParentPost.id, ParentComment.id
         writers.get(COMMENT).writeEntry(dates1, ImmutableList.of(
                 Long.toString(comment.getMessageId()),
                 comment.getIpAddress().toString(),
@@ -143,7 +143,7 @@ public class DynamicActivitySerializer extends LdbcSerializer {
 
         List<String> dates2 = ImmutableList.of(formatDateTime(comment.getCreationDate()), formatDateTime(comment.getDeletionDate()));
         for (Integer t : comment.getTags()) {
-            // creationDate, deletionDate Comment.id, Tag.id
+            // creationDate, deletionDate, Comment.id, Tag.id
             writers.get(COMMENT_HASTAG_TAG).writeEntry(dates2, ImmutableList.of(
                     Long.toString(comment.getMessageId()),
                     Integer.toString(t)
@@ -154,7 +154,7 @@ public class DynamicActivitySerializer extends LdbcSerializer {
     public void serialize(final Photo photo) {
         List<String> dates1 = ImmutableList.of(formatDateTime(photo.getCreationDate()), formatDateTime(photo.getDeletionDate()), String.valueOf(photo.isExplicitlyDeleted()));
 
-        // creationDate, deletionDate, explicitlyDeleted, id, imageFile, locationIP, browserUsed, language, content, length, creator, Forum.id, place
+        // creationDate, deletionDate, explicitlyDeleted, id, imageFile, locationIP, browserUsed, language, content, length, CreatorPerson.id, ContainerForum.id, LocationCountry.id
         writers.get(POST).writeEntry(dates1, ImmutableList.of(
                 Long.toString(photo.getMessageId()),
                 photo.getContent(),
@@ -170,7 +170,7 @@ public class DynamicActivitySerializer extends LdbcSerializer {
 
         List<String> dates2 = ImmutableList.of(formatDateTime(photo.getCreationDate()), formatDateTime(photo.getDeletionDate()));
         for (Integer t : photo.getTags()) {
-            // creationDate, deletionDate Post.id, Tag.id
+            // creationDate, deletionDate, Post.id, Tag.id
             writers.get(POST_HASTAG_TAG).writeEntry(dates2, ImmutableList.of(
                     Long.toString(photo.getMessageId()),
                     Integer.toString(t)
@@ -191,7 +191,9 @@ public class DynamicActivitySerializer extends LdbcSerializer {
     public void serialize(final Like like) {
         List<String> dates = ImmutableList.of(formatDateTime(like.getCreationDate()), formatDateTime(like.getDeletionDate()), String.valueOf(like.isExplicitlyDeleted()));
 
-        // creationDate, deletionDate, explicitlyDeleted, Person.id, Message.id
+        // creationDate, deletionDate, explicitlyDeleted, Person.id, Post.id
+        // or
+        // creationDate, deletionDate, explicitlyDeleted, Person.id, Comment.id
         List<String> arguments = ImmutableList.of(
                 Long.toString(like.getPerson()),
                 Long.toString(like.getMessageId())
@@ -202,7 +204,6 @@ public class DynamicActivitySerializer extends LdbcSerializer {
             writers.get(PERSON_LIKES_COMMENT).writeEntry(dates, arguments);
         }
     }
-
 
     @Override
     protected boolean isDynamic() {

--- a/src/main/java/ldbc/snb/datagen/serializer/DynamicPersonSerializer.java
+++ b/src/main/java/ldbc/snb/datagen/serializer/DynamicPersonSerializer.java
@@ -90,7 +90,7 @@ public class DynamicPersonSerializer extends LdbcSerializer {
 
         List<String> dates2 = ImmutableList.of(formatDateTime(person.getCreationDate()), formatDateTime(person.getDeletionDate()));
         for (Integer interestIdx : person.getInterests()) {
-            // creationDate, deletionDate Person.id, Tag.id
+            // creationDate, deletionDate, Person.id, Tag.id
             writers.get(PERSON_HASINTEREST_TAG).writeEntry(dates2, ImmutableList.of(
                     Long.toString(person.getAccountId()),
                     Integer.toString(interestIdx)
@@ -101,7 +101,7 @@ public class DynamicPersonSerializer extends LdbcSerializer {
     public void serialize(final StudyAt studyAt, final Person person) {
         List<String> dates = ImmutableList.of(formatDateTime(person.getCreationDate()), formatDateTime(person.getDeletionDate()));
 
-        // creationDate, deletionDate Person.id, University.id, classYear
+        // creationDate, deletionDate, Person.id, University.id, classYear
         writers.get(PERSON_STUDYAT_UNIVERSITY).writeEntry(dates, ImmutableList.of(
                 Long.toString(studyAt.person),
                 Long.toString(studyAt.university),
@@ -112,7 +112,7 @@ public class DynamicPersonSerializer extends LdbcSerializer {
     public void serialize(final WorkAt workAt, final Person person) {
         List<String> dates = ImmutableList.of(formatDateTime(person.getCreationDate()), formatDateTime(person.getDeletionDate()));
 
-        // creationDate, deletionDate Person.id, Company.id, workFrom
+        // creationDate, deletionDate, Person.id, Company.id, workFrom
         writers.get(PERSON_WORKAT_COMPANY).writeEntry(dates, ImmutableList.of(
                 Long.toString(workAt.person),
                 Long.toString(workAt.company),

--- a/src/main/java/ldbc/snb/datagen/serializer/DynamicPersonSerializer.java
+++ b/src/main/java/ldbc/snb/datagen/serializer/DynamicPersonSerializer.java
@@ -60,7 +60,7 @@ public class DynamicPersonSerializer extends LdbcSerializer {
         List<String> dates1 = ImmutableList.of("creationDate", "deletionDate", "explicitlyDeleted");
 
         // one-to-many edges, single- and multi-valued attributes
-        writers.get(PERSON)                     .writeHeader(dates1, ImmutableList.of("id", "firstName", "lastName", "gender", "birthday", "locationIP", "browserUsed", "city", "language", "email"));
+        writers.get(PERSON)                     .writeHeader(dates1, ImmutableList.of("id", "firstName", "lastName", "gender", "birthday", "locationIP", "browserUsed", "LocationCity.id", "language", "email"));
 
         // many-to-many edges
         writers.get(PERSON_KNOWS_PERSON)        .writeHeader(dates1, ImmutableList.of("Person1.id", "Person2.id"));
@@ -74,7 +74,7 @@ public class DynamicPersonSerializer extends LdbcSerializer {
     public void serialize(final Person person) {
         List<String> dates1 = ImmutableList.of(formatDateTime(person.getCreationDate()), formatDateTime(person.getDeletionDate()), String.valueOf(person.isExplicitlyDeleted()));
 
-        // creationDate, deletionDate, explicitlyDeleted, id, firstName, lastName, gender, birthday, locationIP, browserUsed, isLocatedIn, language, email
+        // creationDate, deletionDate, explicitlyDeleted, id, firstName, lastName, gender, birthday, locationIP, browserUsed, LocationCity.id, language, email
         writers.get(PERSON).writeEntry(dates1, ImmutableList.of(
                 Long.toString(person.getAccountId()),
                 person.getFirstName(),

--- a/src/main/scala/ldbc/snb/datagen/transformation/TransformationStage.scala
+++ b/src/main/scala/ldbc/snb/datagen/transformation/TransformationStage.scala
@@ -46,43 +46,43 @@ object TransformationStage extends SparkApp with Logging {
         "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `explicitlyDeleted` BOOLEAN, `id` BIGINT, `locationIP` STRING, `browserUsed` STRING, `content` STRING, `length` INT, `CreatorPersonId` BIGINT, `LocationCountryId` INT, `ParentPostId` BIGINT, `ParentCommentId` BIGINT"
       ),
       Edge("HasTag", "Comment", "Tag", NN) -> Some(
-        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `Comment.id` BIGINT, `Tag.id` INT"
+        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `CommentId` BIGINT, `TagId` INT"
       ),
       Node("Forum") -> Some(
         "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `explicitlyDeleted` BOOLEAN, `id` BIGINT, `title` STRING, `ModeratorPersonId` BIGINT"
       ),
       Edge("HasMember", "Forum", "Person", NN) -> Some(
-        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `explicitlyDeleted` BOOLEAN, `Forum.id` BIGINT, `Person.id` BIGINT"
+        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `explicitlyDeleted` BOOLEAN, `ForumId` BIGINT, `PersonId` BIGINT"
       ),
       Edge("HasTag", "Forum", "Tag", NN) -> Some(
-        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `Forum.id` BIGINT, `Tag.id` INT"
+        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `ForumId` BIGINT, `TagId` INT"
       ),
       Node("Person") -> Some(
         "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `explicitlyDeleted` BOOLEAN, `id` BIGINT, `firstName` STRING, `lastName` STRING, `gender` STRING, `birthday` DATE, `locationIP` STRING, `browserUsed` STRING, `LocationCityId` INT, `language` STRING, `email` STRING"
       ),
       Edge("HasInterest", "Person", "Tag", NN) -> Some(
-        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `Person.id` BIGINT, `Tag.id` INT"
+        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `PersonId` BIGINT, `TagId` INT"
       ),
       Edge("Knows", "Person", "Person", NN) -> Some(
-        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `explicitlyDeleted` BOOLEAN, `Person1.id` BIGINT, `Person2.id` BIGINT"
+        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `explicitlyDeleted` BOOLEAN, `Person1Id` BIGINT, `Person2Id` BIGINT"
       ),
       Edge("Likes", "Person", "Comment", NN) -> Some(
-        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `explicitlyDeleted` BOOLEAN, `Person.id` BIGINT, `Comment.id` BIGINT"
+        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `explicitlyDeleted` BOOLEAN, `PersonId` BIGINT, `CommentId` BIGINT"
       ),
       Edge("Likes", "Person", "Post", NN) -> Some(
-        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `explicitlyDeleted` BOOLEAN, `Person.id` BIGINT, `Post.id` BIGINT"
+        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `explicitlyDeleted` BOOLEAN, `PersonId` BIGINT, `PostId` BIGINT"
       ),
       Edge("StudyAt", "Person", "University", OneN) -> Some(
-        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `Person.id` BIGINT, `University.id` INT, `classYear` INT"
+        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `PersonId` BIGINT, `UniversityId` INT, `classYear` INT"
       ),
       Edge("WorkAt", "Person", "Company", NN) -> Some(
-        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `Person.id` BIGINT, `Company.id` INT, `workFrom` INT"
+        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `PersonId` BIGINT, `CompanyId` INT, `workFrom` INT"
       ),
       Node("Post") -> Some(
         "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `explicitlyDeleted` BOOLEAN, `id` BIGINT, `imageFile` STRING, `locationIP` STRING, `browserUsed` STRING, `language` STRING, `content` STRING, `length` INT, `CreatorPersonId` BIGINT, `ContainerForumId` BIGINT, `LocationCountryId` INT"
       ),
       Edge("HasTag", "Post", "Tag", NN) -> Some(
-        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `Post.id` BIGINT, `Tag.id` INT"
+        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `PostId` BIGINT, `TagId` INT"
       )
     )
   )

--- a/src/main/scala/ldbc/snb/datagen/transformation/TransformationStage.scala
+++ b/src/main/scala/ldbc/snb/datagen/transformation/TransformationStage.scala
@@ -43,13 +43,13 @@ object TransformationStage extends SparkApp with Logging {
         "`id` INT, `name` STRING, `url` STRING, `isSubclassOf` INT"
       ),
       Node("Comment") -> Some(
-        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `explicitlyDeleted` BOOLEAN, `id` BIGINT, `locationIP` STRING, `browserUsed` STRING, `content` STRING, `length` INT, `Person.id` BIGINT, `Country.id` INT, `replyOfPost` BIGINT, `replyOfComment` BIGINT"
+        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `explicitlyDeleted` BOOLEAN, `id` BIGINT, `locationIP` STRING, `browserUsed` STRING, `content` STRING, `length` INT, `CreatorPersonId` BIGINT, `LocationCountryId` INT, `ParentPostId` BIGINT, `ParentCommentId` BIGINT"
       ),
       Edge("HasTag", "Comment", "Tag", NN) -> Some(
         "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `Comment.id` BIGINT, `Tag.id` INT"
       ),
       Node("Forum") -> Some(
-        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `explicitlyDeleted` BOOLEAN, `id` BIGINT, `title` STRING, `moderator` BIGINT"
+        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `explicitlyDeleted` BOOLEAN, `id` BIGINT, `title` STRING, `ModeratorPersonId` BIGINT"
       ),
       Edge("HasMember", "Forum", "Person", NN) -> Some(
         "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `explicitlyDeleted` BOOLEAN, `Forum.id` BIGINT, `Person.id` BIGINT"
@@ -58,7 +58,7 @@ object TransformationStage extends SparkApp with Logging {
         "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `Forum.id` BIGINT, `Tag.id` INT"
       ),
       Node("Person") -> Some(
-        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `explicitlyDeleted` BOOLEAN, `id` BIGINT, `firstName` STRING, `lastName` STRING, `gender` STRING, `birthday` DATE, `locationIP` STRING, `browserUsed` STRING, `City.id` INT, `language` STRING, `email` STRING"
+        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `explicitlyDeleted` BOOLEAN, `id` BIGINT, `firstName` STRING, `lastName` STRING, `gender` STRING, `birthday` DATE, `locationIP` STRING, `browserUsed` STRING, `LocationCityId` INT, `language` STRING, `email` STRING"
       ),
       Edge("HasInterest", "Person", "Tag", NN) -> Some(
         "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `Person.id` BIGINT, `Tag.id` INT"
@@ -79,7 +79,7 @@ object TransformationStage extends SparkApp with Logging {
         "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `Person.id` BIGINT, `Company.id` INT, `workFrom` INT"
       ),
       Node("Post") -> Some(
-        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `explicitlyDeleted` BOOLEAN, `id` BIGINT, `imageFile` STRING, `locationIP` STRING, `browserUsed` STRING, `language` STRING, `content` STRING, `length` INT, `Person.id` BIGINT, `Forum.id` BIGINT, `Country.id` INT"
+        "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `explicitlyDeleted` BOOLEAN, `id` BIGINT, `imageFile` STRING, `locationIP` STRING, `browserUsed` STRING, `language` STRING, `content` STRING, `length` INT, `CreatorPersonId` BIGINT, `ContainerForumId` BIGINT, `LocationCountryId` INT"
       ),
       Edge("HasTag", "Post", "Tag", NN) -> Some(
         "`creationDate` TIMESTAMP, `deletionDate` TIMESTAMP, `Post.id` BIGINT, `Tag.id` INT"

--- a/src/main/scala/ldbc/snb/datagen/transformation/model/package.scala
+++ b/src/main/scala/ldbc/snb/datagen/transformation/model/package.scala
@@ -42,7 +42,7 @@ package object model {
       override val primaryKey: Seq[String] = ((source, destination) match {
           case (s, d) if s == d => Seq(s"${s}1", s"${d}2")
           case (s, d) => Seq(s, d)
-      }).map(name => s"$name.id")
+      }).map(name => s"${name}Id")
 
       override def toString: String = s"$source -[${`type`}]-> $destination"
     }
@@ -53,7 +53,7 @@ package object model {
       override val primaryKey: Seq[String] = ((parent, attribute) match {
         case (s, d) if s == d => Seq(s"${s}1", s"${d}2")
         case (s, d) => Seq(s, d)
-      }).map(name => s"$name.id")
+      }).map(name => s"${name}Id")
       override def toString: String = s"$parent ♢-[${`type`}]-> $attribute"
     }
 

--- a/src/main/scala/ldbc/snb/datagen/transformation/transform/ExplodeAttrs.scala
+++ b/src/main/scala/ldbc/snb/datagen/transformation/transform/ExplodeAttrs.scala
@@ -12,7 +12,7 @@ object ExplodeAttrs extends Transform[Mode.Raw.type, Mode.Raw.type] {
   override def transform(input: In): Out = {
 
     def explodedAttr(attr: Attr, node: DataFrame, column: Column) =
-      attr -> node.select(withRawColumns(attr, $"id".as(s"${attr.parent}.id"), explode(split(column, ";")).as(s"${attr.attribute}.id")))
+      attr -> node.select(withRawColumns(attr, $"id".as(s"${attr.parent}Id"), explode(split(column, ";")).as(s"${attr.attribute}Id")))
 
     val updatedEntities = input.entities.collect {
       case (k@Node("Person", false), v) => Map(

--- a/src/main/scala/ldbc/snb/datagen/transformation/transform/ExplodeEdges.scala
+++ b/src/main/scala/ldbc/snb/datagen/transformation/transform/ExplodeEdges.scala
@@ -41,27 +41,27 @@ object ExplodeEdges extends Transform[Mode.Raw.type, Mode.Raw.type]{
         k -> v.drop("isSubclassOf")
       )
       case (k@Node("Comment", false), v) => Map(
-        explodedEdge(Edge("HasCreator", "Comment", "Person", OneN), v, $"`Person.id`"),
-        explodedEdge(Edge("IsLocatedIn", "Comment", "Country", OneN), v, $"`Country.id`"),
-        explodedEdge(Edge("ReplyOf", "Comment", "Comment", OneN), v, $"replyOfComment"),
-        explodedEdge(Edge("ReplyOf", "Comment", "Post", OneN), v, $"replyOfPost"),
-        k -> v.drop("Person.id", "Country.id", "replyOfPost", "replyOfComment")
+        explodedEdge(Edge("HasCreator", "Comment", "Person", OneN), v, $"CreatorPersonId"),
+        explodedEdge(Edge("IsLocatedIn", "Comment", "Country", OneN), v, $"LocationCountryId"),
+        explodedEdge(Edge("ReplyOf", "Comment", "Post", OneN), v, $"ParentPostId"),
+        explodedEdge(Edge("ReplyOf", "Comment", "Comment", OneN), v, $"ParentCommentId"),
+        k -> v.drop("CreatorPersonId", "LocationCountryId", "ParentPostId", "ParentCommentId")
       )
       case (k@Node("Forum", false), v) => Map(
-        explodedEdge(Edge("HasModerator", "Forum", "Person", OneN), v, $"moderator"),
-        k -> v.drop("moderator")
+        explodedEdge(Edge("HasModerator", "Forum", "Person", OneN), v, $"ModeratorPersonId"),
+        k -> v.drop("ModeratorPersonId")
       )
 
       case (k@Node("Person", false), v) => Map(
-        explodedEdge(Edge("IsLocatedIn", "Person", "City", OneN), v, $"`City.id`"),
-        k -> v.drop("City.id")
+        explodedEdge(Edge("IsLocatedIn", "Person", "City", OneN), v, $"LocationCityId"),
+        k -> v.drop("LocationCityId")
       )
 
       case (k@Node("Post", false), v) => Map(
-        explodedEdge(Edge("HasCreator", "Post", "Person", OneN), v, $"`Person.id`"),
-        explodedEdge(Edge("IsLocatedIn", "Post", "Country", OneN), v, $"`Country.id`"),
-        explodedEdge(Edge("ContainerOf", "Forum", "Post", NOne), v, $"`Forum.id`"),
-        k -> v.drop("Person.id", "Country.id", "Forum.id")
+        explodedEdge(Edge("HasCreator", "Post", "Person", OneN), v, $"CreatorPersonId"),
+        explodedEdge(Edge("IsLocatedIn", "Post", "Country", OneN), v, $"LocationCountryId"),
+        explodedEdge(Edge("ContainerOf", "Forum", "Post", NOne), v, $"ContainerForumId"),
+        k -> v.drop("CreatorPersonId", "LocationCountryId", "ContainerForumId")
       )
     }.foldLeft(entities)(_ ++ _)
 

--- a/src/main/scala/ldbc/snb/datagen/transformation/transform/RawToBiTransform.scala
+++ b/src/main/scala/ldbc/snb/datagen/transformation/transform/RawToBiTransform.scala
@@ -53,6 +53,7 @@ case class RawToBiTransform(mode: BI, simulationStart: Long, simulationEnd: Long
       val idColumns = tpe.primaryKey.map(qcol)
       df
         .filter(inBatch($"deletionDate", batchStart, batchEnd))
+        .filter(if (df.columns.contains("explicitlyDeleted")) "explicitlyDeleted" else "true")
         .pipe(batched)
         .select(Seq($"delete_batch_id".as("batch_id"), $"deletionDate") ++ idColumns: _*)
         .repartitionByRange($"batch_id")

--- a/src/main/scala/ldbc/snb/datagen/transformation/transform/RawToBiTransform.scala
+++ b/src/main/scala/ldbc/snb/datagen/transformation/transform/RawToBiTransform.scala
@@ -53,7 +53,7 @@ case class RawToBiTransform(mode: BI, simulationStart: Long, simulationEnd: Long
       val idColumns = tpe.primaryKey.map(qcol)
       df
         .filter(inBatch($"deletionDate", batchStart, batchEnd))
-        .filter(if (df.columns.contains("explicitlyDeleted")) "explicitlyDeleted" else "true")
+        .filter(if (df.columns.contains("explicitlyDeleted")) col("explicitlyDeleted") else lit(true))
         .pipe(batched)
         .select(Seq($"delete_batch_id".as("batch_id"), $"deletionDate") ++ idColumns: _*)
         .repartitionByRange($"batch_id")


### PR DESCRIPTION
Change header attribute names in generated CSVs, e.g. `Person.id` -> `PersonId`; `city`/`City.id` -> `CityId`, etc.
Also fixed the issue that the `explicitlyDeleted` flag not taken into account and rows with `explicitlyDeleted == false` were serialized in the `delete/` files.