### PR TITLE
Remove unnecessary entities from deletes and add cmdline flag

### DIFF
--- a/src/main/scala/ldbc/snb/datagen/spark/LdbcDatagen.scala
+++ b/src/main/scala/ldbc/snb/datagen/spark/LdbcDatagen.scala
@@ -86,8 +86,8 @@ object LdbcDatagen extends SparkApp {
 
       opt[Unit]("keep-implicit-deletes")
         .action((x, c) => args.keepImplicitDeletes.set(c)(true))
-        .text("Keep implicit deletes. Only applicable to BI mode. By default the BI output doesn't contain dynamic entities that" +
-          "without the explicitlyDeleted attribute and filters dynamic entities where explicitlyDeleted is false. " +
+        .text("Keep implicit deletes. Only applicable to BI mode. By default the BI output doesn't contain dynamic entities" +
+          "without the explicitlyDeleted attribute and removes the rows where the attribute is false." +
           "Setting this flag retains all deletes.")
 
       opt[Map[String,String]]("format-options")

--- a/src/main/scala/ldbc/snb/datagen/spark/LdbcDatagen.scala
+++ b/src/main/scala/ldbc/snb/datagen/spark/LdbcDatagen.scala
@@ -20,6 +20,7 @@ object LdbcDatagen extends SparkApp {
     bulkloadPortion: Double = 0.1,
     explodeEdges: Boolean = false,
     explodeAttrs: Boolean = false,
+    keepImplicitDeletes: Boolean = false,
     mode: String = "raw",
     batchPeriod: String = "day",
     numThreads: Option[Int] = None,
@@ -83,6 +84,12 @@ object LdbcDatagen extends SparkApp {
         .action((x, c) => args.format.set(c)(x))
         .text("Output format. Currently, Spark Datasource formats are supported, such as 'csv', 'parquet' or 'orc'.")
 
+      opt[Unit]("keep-implicit-deletes")
+        .action((x, c) => args.keepImplicitDeletes.set(c)(true))
+        .text("Keep implicit deletes. Only applicable to BI mode. By default the BI output doesn't contain dynamic entities that" +
+          "without the explicitlyDeleted attribute and filters dynamic entities where explicitlyDeleted is false. " +
+          "Setting this flag retains all deletes.")
+
       opt[Map[String,String]]("format-options")
         .action((x, c) => args.formatOptions.set(c)(x))
         .text("Output format options specified as key=value1[,key=value...]. See format options for specific formats " +
@@ -116,6 +123,7 @@ object LdbcDatagen extends SparkApp {
       outputDir = args.outputDir,
       explodeEdges = args.explodeEdges,
       explodeAttrs = args.explodeAttrs,
+      keepImplicitDeletes = args.keepImplicitDeletes,
       simulationStart = Dictionaries.dates.getSimulationStart,
       simulationEnd = Dictionaries.dates.getSimulationEnd,
       mode = args.mode match {

--- a/src/main/scala/ldbc/snb/datagen/transformation/TransformationStage.scala
+++ b/src/main/scala/ldbc/snb/datagen/transformation/TransformationStage.scala
@@ -18,6 +18,7 @@ object TransformationStage extends SparkApp with Logging {
     outputDir: String = "out",
     explodeEdges: Boolean = false,
     explodeAttrs: Boolean = false,
+    keepImplicitDeletes: Boolean = false,
     simulationStart: Long = 0,
     simulationEnd: Long = 0,
     mode: Mode = Mode.Raw,
@@ -110,7 +111,7 @@ object TransformationStage extends SparkApp with Logging {
       .pipe[OutputTypes] {
         g =>
           args.mode match {
-            case bi@Mode.BI(_, _) => Inr(Inr(Inl(RawToBiTransform(bi, args.simulationStart, args.simulationEnd).transform(g))))
+            case bi@Mode.BI(_, _) => Inr(Inr(Inl(RawToBiTransform(bi, args.simulationStart, args.simulationEnd, args.keepImplicitDeletes).transform(g))))
             case interactive@Mode.Interactive(_) => Inr(Inl(RawToInteractiveTransform(interactive, args.simulationStart, args.simulationEnd).transform(g)))
             case Mode.Raw => Inl(g)
           }


### PR DESCRIPTION
Add CLI flag `--keep-implicit-deletes` for serializing all deletions in BI mode.
- The default behavior is to only serialize entities that have the explicitlyDeleted attribute and it is true.
- If the flag is set, all delete entities must be serialized regardless of the existence/value of the explicitlyDeleted attribute. 
