### PR TITLE
Fix incorrect Comment generation

### DIFF
--- a/src/main/java/ldbc/snb/datagen/generator/generators/CommentGenerator.java
+++ b/src/main/java/ldbc/snb/datagen/generator/generators/CommentGenerator.java
@@ -124,7 +124,7 @@ public class CommentGenerator {
 
             // creation date
             long minCreationDate = Math.max(parentMessage.getCreationDate(), membership.getCreationDate()) + DatagenParams.delta;
-            long maxCreationDate = Math.min(membership.getDeletionDate(), Dictionaries.dates.getSimulationEnd());
+            long maxCreationDate = Collections.min(Arrays.asList(membership.getDeletionDate(), parentMessage.getDeletionDate(), Dictionaries.dates.getSimulationEnd()));
             if (maxCreationDate <= minCreationDate) {
                 return Iterators.ForIterator.CONTINUE();
             }


### PR DESCRIPTION
Comments were generated incorrectly as a child comment could be created
as a `replyOf` a parent comment that no longer existed