### PR TITLE
Sort collection of Persons before assigning them to blocks. Fixes #306

### DIFF
--- a/src/main/scala/ldbc/snb/datagen/generation/serializer/SparkActivitySerializer.scala
+++ b/src/main/scala/ldbc/snb/datagen/generation/serializer/SparkActivitySerializer.scala
@@ -15,6 +15,7 @@ import org.apache.spark.sql.SparkSession
 
 import java.nio.charset.StandardCharsets
 import java.util
+import java.util.Collections
 import java.util.function.Consumer
 import scala.collection.JavaConverters._
 
@@ -68,6 +69,7 @@ object SparkActivitySerializer {
             }
             friends.write(strbuf.toString().getBytes(StandardCharsets.UTF_8))
           }
+          Collections.sort(clonedPersons)
 
           val activities = generator.generateActivityForBlock(blockId.toInt, clonedPersons)
 


### PR DESCRIPTION
Tested with SF30 on two EMR machines and a local server. The two yielded the same results, same #rows and same hashes (with the headers omitted in both cases):

```
$ for i in Person Forum Post Comment; do echo $i; tail -qn +2 sf30-emr/*/${i}/*.csv | sort -T ~/tmp | md5sum; done
Person
42913430e3d8ac51ca75aa437eb8be69  -
Forum
07570e4685a14ef59d55edd4ace5fe49  -
Post
8a3c52b7753c8522a5eeb2044cea4480  -
Comment
cc6c78bc873ee13b31dab19be32540b2  -
```

```
$ for i in Person Forum Post Comment; do echo $i; tail -qn +2 sf30-local/csv/raw/composite-merged-fk/*/${i}/*.csv | sort -T ~/tmp | md5sum; done
Person
42913430e3d8ac51ca75aa437eb8be69  -
Forum
07570e4685a14ef59d55edd4ace5fe49  -
Post
8a3c52b7753c8522a5eeb2044cea4480  -
Comment
cc6c78bc873ee13b31dab19be32540b2  -
```