### PR TITLE
Use snapshot partitions as bi insert/delete baseline

### DIFF
--- a/src/main/scala/ldbc/snb/datagen/LdbcDatagen.scala
+++ b/src/main/scala/ldbc/snb/datagen/LdbcDatagen.scala
@@ -31,6 +31,8 @@ object LdbcDatagen extends SparkApp {
       oversizeFactor: Option[Double] = None
   )
 
+  override type ArgsType = Args
+
   def main(args: Array[String]): Unit = {
     val parser = new scopt.OptionParser[Args](getClass.getName.dropRight(1)) {
       head(appName)
@@ -124,7 +126,6 @@ object LdbcDatagen extends SparkApp {
   }
 
   def run(args: Args): Unit = {
-
     val env      = System.getenv().asScala
     val irFormat = env.getOrElse("LDBC_DATAGEN_IR_FORMAT", "parquet")
 
@@ -138,11 +139,7 @@ object LdbcDatagen extends SparkApp {
       oversizeFactor = args.oversizeFactor
     )
 
-    val generatorConfig = GenerationStage.buildConfig(generatorArgs)
-
-    DatagenContext.initialize(generatorConfig)
-
-    GenerationStage.run(generatorArgs, generatorConfig)
+    GenerationStage.run(generatorArgs)
 
     if (args.generateFactors) {
       val factorArgs = FactorGenerationStage.Args(outputDir = args.outputDir, irFormat = irFormat)

--- a/src/main/scala/ldbc/snb/datagen/io/graphs.scala
+++ b/src/main/scala/ldbc/snb/datagen/io/graphs.scala
@@ -6,6 +6,7 @@ import ldbc.snb.datagen.model.Mode.Raw
 import ldbc.snb.datagen.model._
 import ldbc.snb.datagen.syntax._
 import ldbc.snb.datagen.util.{Logging, SparkUI}
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 import shapeless.{Generic, Poly1}
@@ -120,12 +121,24 @@ object graphs {
           log.info(s"$tpe: Writing snapshot completed")
         }(snapshot.sparkSession)
 
-        for { (operation, batches) <- Map("inserts" -> insertBatches, "deletes" -> deleteBatches) } {
-          batches.foreach { case Batched(entity, partitionKeys) =>
+        val insertSizeFactor = 0.247
+        val deleteSizeFactor = 0.015
+
+        val operations = Map(
+          "inserts" -> (insertBatches, insertSizeFactor),
+          "deletes" -> (deleteBatches, deleteSizeFactor)
+        )
+
+        for { (operation, (batches, sizeFactor)) <- operations } {
+          batches.foreach { case Batched(entity, partitionKeys, orderingKeys) =>
             SparkUI.job(getClass.getSimpleName, s"write $tpe $operation") {
-              val p = (sink.path / "graphs" / sink.format / PathComponent[GraphLike[M]].path(self) / operation / tpe.entityPath).toString
+              val p             = (sink.path / "graphs" / sink.format / PathComponent[GraphLike[M]].path(self) / operation / tpe.entityPath).toString
+              val numPartitions = Math.max(1.0, entity.rdd.getNumPartitions * sizeFactor).toInt
               log.info(f"$tpe: Writing $operation")
-              entity.write(DataFrameSink(p, sink.format, opts, SaveMode.Ignore, partitionBy = partitionKeys))
+              entity
+                .repartitionByRange(numPartitions, orderingKeys: _*)
+                .sortWithinPartitions(orderingKeys: _*)
+                .write(DataFrameSink(p, sink.format, opts, SaveMode.Ignore, partitionBy = partitionKeys))
               log.info(f"$tpe: Writing $operation completed")
             }(entity.sparkSession)
           }

--- a/src/main/scala/ldbc/snb/datagen/model/package.scala
+++ b/src/main/scala/ldbc/snb/datagen/model/package.scala
@@ -105,7 +105,7 @@ package object model {
     }
   }
 
-  case class Batched(entity: DataFrame, batchId: Seq[String])
+  case class Batched(entity: DataFrame, batchId: Seq[String], ordering: Seq[Column])
 
   case class BatchedEntity(
       snapshot: DataFrame,

--- a/src/main/scala/ldbc/snb/datagen/transformation/TransformationStage.scala
+++ b/src/main/scala/ldbc/snb/datagen/transformation/TransformationStage.scala
@@ -23,11 +23,13 @@ object TransformationStage extends DatagenStage with Logging {
       formatOptions: Map[String, String] = Map.empty
   )
 
+  override type ArgsType = Args
+
   import ldbc.snb.datagen.io.Reader.ops._
   import ldbc.snb.datagen.io.Writer.ops._
   import ldbc.snb.datagen.io.instances._
 
-  def run(args: Args)(implicit spark: SparkSession) = {
+  def run(args: ArgsType) = {
     object write extends Poly1 {
       implicit def caseSimple[M <: Mode](implicit ev: M#Layout =:= DataFrame) =
         at[Graph[M]](g => g.write(GraphSink(args.outputDir, args.format, args.formatOptions)))

--- a/src/main/scala/ldbc/snb/datagen/util/SparkApp.scala
+++ b/src/main/scala/ldbc/snb/datagen/util/SparkApp.scala
@@ -4,7 +4,10 @@ import ldbc.snb.datagen.syntax._
 import org.apache.spark.sql.SparkSession
 
 trait SparkApp {
+  type ArgsType
   def appName: String
+
+  def run(args: ArgsType): Unit
 
   implicit def spark: SparkSession = SparkSession
     .builder()


### PR DESCRIPTION
This approach uses the number of partitions in the original (raw) dataset as the basis for batch partitions.
Closes #314 