### PR TITLE
SF3k, SF10k sizes set, SF10k OOMs

### DIFF
--- a/src/main/resources/scale_factors.xml
+++ b/src/main/resources/scale_factors.xml
@@ -194,7 +194,7 @@
     <scale_factor name="3000" >
         <property>
             <name>generator.numPersons</name>
-            <value>6000000</value>
+            <value>8480000</value>
         </property>
         <property>
             <name>generator.startYear</name>
@@ -213,7 +213,7 @@
     <scale_factor name="10000" >
         <property>
             <name>generator.numPersons</name>
-            <value>20900000</value>
+            <value>26200000</value>
         </property>
         <property>
             <name>generator.startYear</name>

--- a/tools/emr/submit_datagen_job.py
+++ b/tools/emr/submit_datagen_job.py
@@ -24,7 +24,6 @@ defaults = {
     'master_instance_type': 'm5d.2xlarge',
     'instance_type': 'i3.4xlarge',
     'sf_ratio': 100.0, # ratio of SFs and machines. a ratio of 50.0 for SF100 yields 2 machines
-    #'sf_ratio': 240.0, # for limited vCPU counts, this ratio is still sufficient to generate the data
     'platform_version': lib.platform_version,
     'version': lib.version,
     'az': 'us-west-2c',


### PR DESCRIPTION
SF10k runs out of memory on 100 `i3.4xlarge` workers:

```
22/02/03 23:51:58 WARN TaskSetManager: Lost task 2463.0 in stage 43.0 (TID 66463) (ip-172-31-26-182.us-east-2.compute.internal executor 12): java.lang.OutOfMemoryError
	at sun.misc.Unsafe.allocateMemory(Native Method)
	at java.nio.DirectByteBuffer.<init>(DirectByteBuffer.java:127)
	at java.nio.ByteBuffer.allocateDirect(ByteBuffer.java:311)
	at org.apache.parquet.hadoop.codec.SnappyCompressor.setInput(SnappyCompressor.java:97)
	at org.apache.parquet.hadoop.codec.NonBlockedCompressorStream.write(NonBlockedCompressorStream.java:48)
	at org.apache.parquet.bytes.CapacityByteArrayOutputStream.writeToOutput(CapacityByteArrayOutputStream.java:227)
	at org.apache.parquet.bytes.CapacityByteArrayOutputStream.writeTo(CapacityByteArrayOutputStream.java:247)
	at org.apache.parquet.bytes.BytesInput$CapacityBAOSBytesInput.writeAllTo(BytesInput.java:405)
	at org.apache.parquet.bytes.BytesInput$SequenceBytesIn.writeAllTo(BytesInput.java:296)
	at org.apache.parquet.hadoop.CodecFactory$HeapBytesCompressor.compress(CodecFactory.java:164)
	at org.apache.parquet.hadoop.ColumnChunkPageWriteStore$ColumnChunkPageWriter.writePage(ColumnChunkPageWriteStore.java:95)
	at org.apache.parquet.column.impl.ColumnWriterV1.writePage(ColumnWriterV1.java:147)
	at org.apache.parquet.column.impl.ColumnWriterV1.flush(ColumnWriterV1.java:235)
	at org.apache.parquet.column.impl.ColumnWriteStoreV1.flush(ColumnWriteStoreV1.java:122)
	at org.apache.parquet.hadoop.InternalParquetRecordWriter.flushRowGroupToStore(InternalParquetRecordWriter.java:172)
	at org.apache.parquet.hadoop.InternalParquetRecordWriter.close(InternalParquetRecordWriter.java:114)
	at org.apache.parquet.hadoop.ParquetRecordWriter.close(ParquetRecordWriter.java:165)
	at ldbc.snb.datagen.io.raw.parquet$ParquetRecordOutputStream.close(parquet.scala:55)
	at ldbc.snb.datagen.io.raw.package$RoundRobinOutputStream.$anonfun$close$1(package.scala:33)
	at ldbc.snb.datagen.io.raw.package$RoundRobinOutputStream.$anonfun$close$1$adapted(package.scala:33)
	at scala.collection.Iterator.foreach(Iterator.scala:941)
	at scala.collection.Iterator.foreach$(Iterator.scala:941)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1429)
	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
	at ldbc.snb.datagen.io.raw.package$RoundRobinOutputStream.close(package.scala:33)
	at ldbc.snb.datagen.generator.serializers.ActivityOutputStream.close(ActivityOutputStream.scala:201)
	at ldbc.snb.datagen.syntax.UsableInstances$$anon$3.use(UseSyntax.scala:42)
	at ldbc.snb.datagen.syntax.UsableInstances$$anon$3.use(UseSyntax.scala:36)
	at ldbc.snb.datagen.syntax.UsableInstances$ops$$anon$1.use(UseSyntax.scala:21)
	at ldbc.snb.datagen.generator.serializers.RawSerializer.$anonfun$writeActivitySubgraph$3(RawSerializer.scala:88)
	at ldbc.snb.datagen.generator.serializers.RawSerializer.$anonfun$writeActivitySubgraph$3$adapted(RawSerializer.scala:65)
	at org.apache.spark.rdd.RDD.$anonfun$foreachPartition$2(RDD.scala:1020)
	at org.apache.spark.rdd.RDD.$anonfun$foreachPartition$2$adapted(RDD.scala:1020)
	at org.apache.spark.SparkContext.$anonfun$runJob$5(SparkContext.scala:2278)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:131)
	at org.apache.spark.executor.Executor$TaskRunner.$anonfun$run$3(Executor.scala:497)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1439)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:500)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
```