### PR TITLE
Optimize generation & raw serialization

### DIFF
--- a/src/main/scala/ldbc/snb/datagen/LdbcDatagen.scala
+++ b/src/main/scala/ldbc/snb/datagen/LdbcDatagen.scala
@@ -2,7 +2,7 @@ package ldbc.snb.datagen
 
 import ldbc.snb.datagen.factors.FactorGenerationStage
 import ldbc.snb.datagen.generator.dictionary.Dictionaries
-import ldbc.snb.datagen.generator.{DatagenContext, GenerationStage}
+import ldbc.snb.datagen.generator.GenerationStage
 import ldbc.snb.datagen.model.Mode
 import ldbc.snb.datagen.transformation.TransformationStage
 import ldbc.snb.datagen.util.{SparkApp, lower}

--- a/src/main/scala/ldbc/snb/datagen/generator/generators/SparkKnowsGenerator.scala
+++ b/src/main/scala/ldbc/snb/datagen/generator/generators/SparkKnowsGenerator.scala
@@ -8,7 +8,6 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 
 import java.util
-import java.util.Collections
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 

--- a/src/main/scala/ldbc/snb/datagen/generator/generators/SparkKnowsGenerator.scala
+++ b/src/main/scala/ldbc/snb/datagen/generator/generators/SparkKnowsGenerator.scala
@@ -8,8 +8,9 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 
 import java.util
+import java.util.Collections
 import scala.collection.JavaConverters._
-import scala.collection.SortedMap
+import scala.collection.mutable
 
 object SparkKnowsGenerator {
   def apply(
@@ -31,9 +32,9 @@ object SparkKnowsGenerator {
       // groupByKey wouldn't guarantee keeping the order inside groups
       // TODO check if it actually has better performance than sorting inside mapPartitions (probably not)
       .combineByKeyWithClassTag(
-        personByRank => SortedMap(personByRank),
-        (map: SortedMap[Long, Person], personByRank) => map + personByRank,
-        (a: SortedMap[Long, Person], b: SortedMap[Long, Person]) => a ++ b
+        personByRank => mutable.SortedMap(personByRank),
+        (map: mutable.SortedMap[Long, Person], personByRank) => map += personByRank,
+        (a: mutable.SortedMap[Long, Person], b: mutable.SortedMap[Long, Person]) => a ++= b
       )
       .mapPartitions(groups => {
         DatagenContext.initialize(conf)
@@ -43,14 +44,11 @@ object SparkKnowsGenerator {
         val personSimilarity = DatagenParams.getPersonSimularity
 
         val personGroups = for { (block, persons) <- groups } yield {
-          val clonedPersons = new util.ArrayList[Person]
-          for (p <- persons.values) {
-            clonedPersons.add(new Person(p))
-          }
-          knowsGenerator.generateKnows(clonedPersons, block.toInt, percentagesJava, stepIndex, personSimilarity)
-          clonedPersons
+          val personList = new util.ArrayList[Person](persons.size)
+          for (p <- persons.values) { personList.add(p) }
+          knowsGenerator.generateKnows(personList, block.toInt, percentagesJava, stepIndex, personSimilarity)
+          personList
         }
-
         for {
           persons <- personGroups
           person  <- persons.iterator().asScala

--- a/src/main/scala/ldbc/snb/datagen/generator/generators/SparkPersonGenerator.scala
+++ b/src/main/scala/ldbc/snb/datagen/generator/generators/SparkPersonGenerator.scala
@@ -20,7 +20,6 @@ object SparkPersonGenerator {
 
       for {
         i <- blocks
-        _    = println(s"Processing person block $i (${DatagenParams.blockSize})")
         size = Math.min(DatagenParams.numPersons - DatagenParams.blockSize * i, DatagenParams.blockSize).toInt
         person <- personGenerator.generatePersonBlock(i.toInt, DatagenParams.blockSize).asScala.take(size)
       } yield person

--- a/src/main/scala/ldbc/snb/datagen/generator/generators/SparkRanker.scala
+++ b/src/main/scala/ldbc/snb/datagen/generator/generators/SparkRanker.scala
@@ -13,11 +13,9 @@ trait SparkRanker {
 
 object SparkRanker {
 
-  def create[K: Ordering: ClassTag](by: Person => K, numPartitions: Option[Int] = None)(implicit spark: SparkSession): SparkRanker = new SparkRanker {
+  def create[K: Ordering: ClassTag](by: Person => K)(implicit spark: SparkSession): SparkRanker = new SparkRanker {
     override def apply(persons: RDD[Person]): RDD[(Long, Person)] = {
-      val partitions = numPartitions.getOrElse(spark.sparkContext.defaultParallelism)
-
-      val sortedPersons = persons.sortBy(by, numPartitions = partitions).cache()
+      val sortedPersons = persons.sortBy(by).cache()
 
       // single count / partition. Assumed small enough to collect and broadcast
       val counts = sortedPersons

--- a/src/main/scala/ldbc/snb/datagen/syntax/UseSyntax.scala
+++ b/src/main/scala/ldbc/snb/datagen/syntax/UseSyntax.scala
@@ -1,5 +1,7 @@
 package ldbc.snb.datagen.syntax
 
+import shapeless._
+
 import java.io.Closeable
 
 trait Usable[A] {
@@ -42,6 +44,22 @@ trait UsableInstances {
         self.close()
       }
     }
+  }
+
+  implicit def usableForProduct[A <: Product, Repr](implicit gen: Generic.Aux[A, Repr], ev: Usable[Repr]): Usable[A] = new Usable[A] {
+    override def use[Ret](a: A, f: A => Ret): Ret = {
+      ev.use(gen.to(a), f.compose(gen.from))
+    }
+  }
+
+  implicit def usableForHCons[A, Rest <: HList](implicit ev1: Usable[A], ev2: Usable[Rest]): Usable[A :: Rest] = new Usable[A :: Rest] {
+    override def use[Ret](list: A :: Rest, f: (A :: Rest) => Ret): Ret = {
+      ev1.use(list.head, (a: A) => { ev2.use(list.tail, (rest: Rest) => f(a :: rest)) })
+    }
+  }
+
+  implicit val usableForHNil: Usable[HNil] = new Usable[HNil] {
+    override def use[Ret](a: HNil, f: HNil => Ret): Ret = f(a)
   }
 }
 


### PR DESCRIPTION
Micro optimizations:
- remove unnecessary defensive deep copies of persons
  - during edge generation
  - during activity generation
- use `mutable.SortedMap` in `combineByKey` before edge generation
These changes make generation a tiny bit faster and reduce memory footprint (~5%)

Merge person & activity generation:
- persist persons to MEMORY_AND_DISK, which does wonders on low-memory machines
- persist the person graph and the activity graph in the same task.