### PR TITLE
Use Gravitons by default

### DIFF
--- a/tools/emr/submit_datagen_job.py
+++ b/tools/emr/submit_datagen_job.py
@@ -21,8 +21,8 @@ max_num_workers = 1000
 defaults = {
     'bucket': 'ldbc-snb-datagen-store',
     'use_spot': True,
-    'master_instance_type': 'm5d.2xlarge',
-    'instance_type': 'i3.4xlarge',
+    'master_instance_type': 'r6gd.2xlarge',
+    'instance_type': 'r6gd.4xlarge',
     'sf_ratio': 100.0, # ratio of SFs and machines. a ratio of 250.0 for SF1000 yields 4 machines
     'platform_version': lib.platform_version,
     'version': lib.version,


### PR DESCRIPTION
A summary `4xlarge` instances and their per-hour spot/EMR pricing:

| instance | [spot cost in `us-east-2`](https://instances.vantage.sh/?region=us-east-2) | [EMR cost](https://aws.amazon.com/emr/pricing/) | total cost | memory |
|-|-|-|-|-|
| `m5d.4xlarge` | $0.31 |  $0.23 | $0.54 | 64 GiB |
| `m6gd.4xlarge` | $0.29 | $0.18 | $0.47 | 64 GiB |
| `r5d.4xlarge` | $0.36 | $0.27 | $0.63 | 128 GiB |
| `r6gd.4xlarge` | $0.18 | $0.23 | $0.41 | 128 GiB |
| `i3.4xlarge` | $0.47 | $0.27 | $0.74 | 122 GiB |

This shows that `r6gd.4xlarge` are much cheaper than the i3.4xlarge and even offers more memory (plus they have 2nd generation Gravitons, so their CPU performance is probably also pretty good).