### PR TITLE
Fix: generate factor tables on multiple machines

### DIFF
--- a/src/main/scala/ldbc/snb/datagen/factors/io/package.scala
+++ b/src/main/scala/ldbc/snb/datagen/factors/io/package.scala
@@ -21,7 +21,7 @@ package object io {
       val dfSink = if (sink.overwrite) {
         DataFrameSink(p, sink.format, mode = SaveMode.Overwrite)
       } else DataFrameSink(p, sink.format)
-      self.data.coalesce(1).write(dfSink)
+      self.data.write(dfSink)
       log.info(s"Factor table ${self.name} written")
     }
   }


### PR DESCRIPTION
Previously, these were small aggregate tables but now there is a larger table, `sameUniversityKnows`, so it makes sense to parallelize the generation of certain factor tables.