### PR TITLE
Add option to control number of nodes & partitions

### DIFF
--- a/tools/emr/submit_datagen_job.py
+++ b/tools/emr/submit_datagen_job.py
@@ -23,7 +23,7 @@ defaults = {
     'bucket': 'ldbc-snb-datagen-store',
     'use_spot': True,
     'master_instance_type': 'r6gd.2xlarge',
-    'instance_type': 'r6gd.4xlarge',
+    'instance_type': 'i3.4xlarge',
     'sf_per_executor': 3e3,
     'sf_per_partition': 10,
     'az': 'us-west-2c',

--- a/tools/emr/submit_datagen_job.py
+++ b/tools/emr/submit_datagen_job.py
@@ -24,9 +24,9 @@ defaults = {
     'use_spot': True,
     'master_instance_type': 'r6gd.2xlarge',
     'instance_type': 'r6gd.4xlarge',
-    'executors_per_sf': 1e-3,
-    'partitions_per_sf': 1e-1,
-    'az': 'us-east-2c',
+    'sf_per_executors': 3e3,
+    'sf_per_partitions': 1e2,
+    'az': 'us-west-2c',
     'yes': False,
     'ec2_key': None,
     'emr_release': 'emr-6.6.0'
@@ -68,9 +68,9 @@ def submit_datagen_job(name,
                        use_spot,
                        instance_type,
                        executors,
-                       executors_per_sf,
+                       sf_per_executors,
                        partitions,
-                       partitions_per_sf,
+                       sf_per_partitions,
                        master_instance_type,
                        az,
                        emr_release,
@@ -106,10 +106,10 @@ def submit_datagen_job(name,
     }
 
     if executors is None:
-        executors = max(min_num_workers, min(max_num_workers, ceil(sf * executors_per_sf)))
+        executors = max(min_num_workers, min(max_num_workers, ceil(sf / sf_per_executors)))
 
     if partitions is None:
-        partitions = max(min_num_threads, ceil(sf * partitions_per_sf))
+        partitions = max(min_num_threads, ceil(sf / sf_per_partitions))
 
     spark_defaults_config = {
         'spark.serializer': 'org.apache.spark.serializer.KryoSerializer',
@@ -265,20 +265,20 @@ if __name__ == "__main__":
                                type=int,
                                help=f"Total number of Spark executors."
                                )
-    executor_args.add_argument("--executors-per-sf",
+    executor_args.add_argument("--sf-per-executors",
                                type=float,
-                               default=defaults['executors_per_sf'],
-                               help=f"Number of Spark executors per scale factor. Default: {defaults['executors_per_sf']}"
+                               default=defaults['sf_per_executors'],
+                               help=f"Number of Spark executors per scale factor. Default: {defaults['sf_per_executors']}"
                                )
     partitioning_args = parser.add_mutually_exclusive_group()
     partitioning_args.add_argument("--partitions",
                                    type=int,
                                    help=f"Total number of Spark partitions to use when generating the dataset."
                                    )
-    partitioning_args.add_argument("--partitions-per-sf",
+    partitioning_args.add_argument("--sf-per-partitions",
                                    type=float,
-                                   default=defaults['partitions_per_sf'],
-                                   help=f"Number of Spark partitions per scale factor to use when generating the dataset. Default: {defaults['partitions_per_sf']}"
+                                   default=defaults['sf_per_partitions'],
+                                   help=f"Number of Spark partitions per scale factor to use when generating the dataset. Default: {defaults['sf_per_partitions']}"
                                    )
 
     parser.add_argument('--', nargs='*', help='Arguments passed to LDBC SNB Datagen', dest="arg")

--- a/tools/emr/submit_datagen_job.py
+++ b/tools/emr/submit_datagen_job.py
@@ -25,7 +25,7 @@ defaults = {
     'master_instance_type': 'r6gd.2xlarge',
     'instance_type': 'r6gd.4xlarge',
     'sf_per_executor': 3e3,
-    'sf_per_partition': 1e2,
+    'sf_per_partition': 10,
     'az': 'us-west-2c',
     'yes': False,
     'ec2_key': None,

--- a/tools/emr/submit_datagen_job.py
+++ b/tools/emr/submit_datagen_job.py
@@ -9,9 +9,7 @@ import re
 import __main__
 
 from math import ceil
-from botocore.credentials import subprocess
 from datagen import lib, util
-import subprocess
 
 import argparse
 
@@ -19,14 +17,16 @@ from datagen.util import KeyValue, split_passthrough_args
 
 min_num_workers = 1
 max_num_workers = 1000
+min_num_threads = 1
 
 defaults = {
     'bucket': 'ldbc-snb-datagen-store',
     'use_spot': True,
     'master_instance_type': 'r6gd.2xlarge',
     'instance_type': 'r6gd.4xlarge',
-    'sf_ratio': 100.0,  # ratio of SFs and machines. a ratio of 250.0 for SF1000 yields 4 machines
-    'az': 'us-west-2c',
+    'executors_per_sf': 1e-3,
+    'partitions_per_sf': 1e-1,
+    'az': 'us-east-2c',
     'yes': False,
     'ec2_key': None,
     'emr_release': 'emr-6.6.0'
@@ -41,15 +41,6 @@ ec2info_file = 'Amazon EC2 Instance Comparison.csv'
 with open(path.join(dir, ec2info_file), mode='r') as infile:
     reader = csv.DictReader(infile)
     ec2_instances = [dict(row) for row in reader]
-
-
-def calculate_cluster_config(scale_factor, sf_ratio, vcpu):
-    num_workers = max(min_num_workers, min(max_num_workers, ceil(scale_factor / sf_ratio)))
-    num_threads = ceil(num_workers * vcpu * 2)
-    return {
-        'num_workers': num_workers,
-        'num_threads': num_threads
-    }
 
 
 def get_instance_info(instance_type):
@@ -76,7 +67,10 @@ def submit_datagen_job(name,
                        jar,
                        use_spot,
                        instance_type,
-                       sf_ratio,
+                       executors,
+                       executors_per_sf,
+                       partitions,
+                       partitions_per_sf,
                        master_instance_type,
                        az,
                        emr_release,
@@ -97,10 +91,6 @@ def submit_datagen_job(name,
     else:
         copy_filter = f'.*{build_dir}/{copy_filter}'
 
-    exec_info = get_instance_info(instance_type)
-
-    cluster_config = calculate_cluster_config(sf, sf_ratio, exec_info['vcpu'])
-
     emr = boto3.client('emr')
 
     ts = datetime.utcnow()
@@ -115,8 +105,15 @@ def submit_datagen_job(name,
         'maximizeResourceAllocation': 'true'
     }
 
+    if executors is None:
+        executors = max(min_num_workers, min(max_num_workers, ceil(sf * executors_per_sf)))
+
+    if partitions is None:
+        partitions = max(min_num_threads, ceil(sf * partitions_per_sf))
+
     spark_defaults_config = {
         'spark.serializer': 'org.apache.spark.serializer.KryoSerializer',
+        'spark.default.parallelism': str(partitions),
         **(dict(conf) if conf else {})
     }
 
@@ -157,7 +154,7 @@ def submit_datagen_job(name,
                     'Market': market,
                     'InstanceRole': 'CORE',
                     'InstanceType': instance_type,
-                    'InstanceCount': cluster_config['num_workers'],
+                    'InstanceCount': executors,
                 }
             ],
             **ec2_key_dict,
@@ -178,7 +175,7 @@ def submit_datagen_job(name,
                     'Args': ['spark-submit', '--class', lib.main_class, jar_url,
                              '--output-dir', build_dir,
                              '--scale-factor', str(sf),
-                             '--num-threads', str(cluster_config['num_threads']),
+                             '--num-threads', str(partitions),
                              '--mode', mode,
                              '--format', format,
                              *passthrough_args
@@ -263,6 +260,26 @@ if __name__ == "__main__":
                             nargs='+',
                             action=KeyValue,
                             help="SparkConf as key=value pairs")
+    executor_args=parser.add_mutually_exclusive_group()
+    executor_args.add_argument("--executors",
+                               type=int,
+                               help=f"Total number of Spark executors."
+                               )
+    executor_args.add_argument("--executors-per-sf",
+                               type=float,
+                               default=defaults['executors_per_sf'],
+                               help=f"Number of Spark executors per scale factor. Default: {defaults['executors_per_sf']}"
+                               )
+    partitioning_args = parser.add_mutually_exclusive_group()
+    partitioning_args.add_argument("--partitions",
+                                   type=int,
+                                   help=f"Total number of Spark partitions to use when generating the dataset."
+                                   )
+    partitioning_args.add_argument("--partitions-per-sf",
+                                   type=float,
+                                   default=defaults['partitions_per_sf'],
+                                   help=f"Number of Spark partitions per scale factor to use when generating the dataset. Default: {defaults['partitions_per_sf']}"
+                                   )
 
     parser.add_argument('--', nargs='*', help='Arguments passed to LDBC SNB Datagen', dest="arg")
 
@@ -271,6 +288,5 @@ if __name__ == "__main__":
     args = parser.parse_args(self_args)
 
     submit_datagen_job(passthrough_args=passthrough_args,
-                       sf_ratio=defaults['sf_ratio'],
                        master_instance_type=defaults['master_instance_type'],
                        **args.__dict__)

--- a/tools/emr/submit_datagen_job.py
+++ b/tools/emr/submit_datagen_job.py
@@ -24,8 +24,8 @@ defaults = {
     'use_spot': True,
     'master_instance_type': 'r6gd.2xlarge',
     'instance_type': 'r6gd.4xlarge',
-    'sf_per_executors': 3e3,
-    'sf_per_partitions': 1e2,
+    'sf_per_executor': 3e3,
+    'sf_per_partition': 1e2,
     'az': 'us-west-2c',
     'yes': False,
     'ec2_key': None,
@@ -68,9 +68,9 @@ def submit_datagen_job(name,
                        use_spot,
                        instance_type,
                        executors,
-                       sf_per_executors,
+                       sf_per_executor,
                        partitions,
-                       sf_per_partitions,
+                       sf_per_partition,
                        master_instance_type,
                        az,
                        emr_release,
@@ -106,10 +106,10 @@ def submit_datagen_job(name,
     }
 
     if executors is None:
-        executors = max(min_num_workers, min(max_num_workers, ceil(sf / sf_per_executors)))
+        executors = max(min_num_workers, min(max_num_workers, ceil(sf / sf_per_executor)))
 
     if partitions is None:
-        partitions = max(min_num_threads, ceil(sf / sf_per_partitions))
+        partitions = max(min_num_threads, ceil(sf / sf_per_partition))
 
     spark_defaults_config = {
         'spark.serializer': 'org.apache.spark.serializer.KryoSerializer',
@@ -265,20 +265,20 @@ if __name__ == "__main__":
                                type=int,
                                help=f"Total number of Spark executors."
                                )
-    executor_args.add_argument("--sf-per-executors",
+    executor_args.add_argument("--sf-per-executor",
                                type=float,
-                               default=defaults['sf_per_executors'],
-                               help=f"Number of Spark executors per scale factor. Default: {defaults['sf_per_executors']}"
+                               default=defaults['sf_per_executor'],
+                               help=f"Number of scale factors per Spark executor. Default: {defaults['sf_per_executor']}"
                                )
     partitioning_args = parser.add_mutually_exclusive_group()
     partitioning_args.add_argument("--partitions",
                                    type=int,
                                    help=f"Total number of Spark partitions to use when generating the dataset."
                                    )
-    partitioning_args.add_argument("--sf-per-partitions",
+    partitioning_args.add_argument("--sf-per-partition",
                                    type=float,
-                                   default=defaults['sf_per_partitions'],
-                                   help=f"Number of Spark partitions per scale factor to use when generating the dataset. Default: {defaults['sf_per_partitions']}"
+                                   default=defaults['sf_per_partition'],
+                                   help=f"Number of scale factors per Spark partitions. Default: {defaults['sf_per_partition']}"
                                    )
 
     parser.add_argument('--', nargs='*', help='Arguments passed to LDBC SNB Datagen', dest="arg")


### PR DESCRIPTION
The goal of this PR is to facilitate dataset generation on smaller Spark clusters on EMR. 

Our experiments show that a machine with 128GB of memory is capable of generating SF3K reliably with 3 blocks per partition given ample disk size to allow for spills (tested with 3.8TB); while less partitions (subsequently, larger block/partition ratio) would introduce OOM errors for this configuration.
This PR:
- sets `spark.default.parallelism` to the desired partition number (i.e the same value as `--num-threads`). This makes sure that after wide operations (e.g. the sorting), we don't fall back to a risky, lower value. This is the same behaviour as `run.py`.
- renames the `sf_ratio` parameter to `sf_per_executor` with the same semantics (scale factor for each executor node). The default value is changed to 3000, i.e. 3000 SF for each executor.
- introduces the `executors` parameter mutually exclusive with the former, to allow for absolutely setting the number of executor nodes.
- analogously to the former two, introduces the `sf_per_partition` and `partitions` parameters to set the desired partition number. The default is `sf_per_partitions = 100`


The following combinations are tested and work. Partition numbers are given as absolute values and they were calculated for each scale factor using the formula `ceil(persons_in_sf / block_size / 3)`, to make sure each partition contains no more than 3 blocks.

```shell
./tools/emr/submit_datagen_job.py sf3k_bi 3000 parquet bi --sf-per-executor 3000 --partitions 330 --jar $JAR_NAME --instance-type i3.4xlarge --bucket $BUCKET_NAME  -- --explode-edges --explode-attrs
```

~11 hours

```shell
./tools/emr/submit_datagen_job.py sf10k_bi 10000 parquet bi --sf-per-executor 3000 --partitions 1000 --jar $JAR_NAME --instance-type i3.4xlarge --bucket $BUCKET_NAME  -- --explode-edges --explode-attrs
```

~ 11 hours


