### PR TITLE
Factor table: Connected components of university relations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ resolvers += "TUDelft Repository" at "https://simulation.tudelft.nl/maven/"
 libraryDependencies ++= Seq(
   "org.apache.spark" %%  "spark-sql" % sparkVersion.value % "provided",
   "org.apache.spark" %%  "spark-core" % sparkVersion.value % "provided",
+  "org.apache.spark" %%  "spark-graphx" % sparkVersion.value % "provided",
   "com.chuusai" %%  "shapeless" % "2.3.3",
   "com.github.scopt" %%  "scopt" % "3.7.1",
   "org.javatuples" %  "javatuples" % "1.2",

--- a/src/main/scala/ldbc/snb/datagen/factors/FactorGenerationStage.scala
+++ b/src/main/scala/ldbc/snb/datagen/factors/FactorGenerationStage.scala
@@ -8,8 +8,9 @@ import ldbc.snb.datagen.model.Mode.Raw
 import ldbc.snb.datagen.syntax._
 import ldbc.snb.datagen.transformation.transform.ConvertDates
 import ldbc.snb.datagen.util.{DatagenStage, Logging}
+import org.apache.spark.graphx
 import org.apache.spark.sql.functions.{broadcast, col, count, date_trunc, expr, floor, lit, sum}
-import org.apache.spark.sql.{Column, DataFrame, functions}
+import org.apache.spark.sql.{Column, DataFrame, Row, functions}
 import shapeless._
 
 import scala.util.matching.Regex
@@ -139,6 +140,20 @@ object FactorGenerationStage extends DatagenStage with Logging {
       value = $"MessageHasTag.TagId",
       by = Seq($"Tag.id", $"Tag.name")
     ).select($"Tag.id".as("tagId"), $"Tag.name".as("tagName"), $"frequency")
+  }
+
+  private def sameUniversityKnows(personKnowsPerson: DataFrame, studyAt: DataFrame) = {
+    undirectedKnowsTemporal(personKnowsPerson)
+      .join(studyAt.as("studyAt1"), $"studyAt1.personId" === $"knows.person1Id")
+      .join(studyAt.as("studyAt2"), $"studyAt2.personId" === $"knows.person2Id")
+      .where($"studyAt1.universityId" === $"studyAt2.universityId")
+      .select(
+        $"knows.person1Id".as("person1Id"),
+        $"knows.person2Id".as("person2Id"),
+        functions.greatest($"knows.creationDate", $"studyAt1.creationDate", $"studyAt2.creationDate").alias("creationDate"),
+        functions.least($"knows.deletionDate", $"studyAt1.deletionDate", $"studyAt2.deletionDate").alias("deletionDate")
+      )
+      .where($"creationDate" < $"deletionDate")
   }
 
   import model.raw._
@@ -446,21 +461,6 @@ object FactorGenerationStage extends DatagenStage with Logging {
       val sampleFractionPersonPairs = Math.min(10000.0 / personPairs.count(), 1.0)
       personPairs.sample(sampleFractionPersonPairs, 42)
     },
-    "sameUniversityKnows" -> LargeFactor(PersonKnowsPersonType, PersonStudyAtUniversityType) { case Seq(personKnowsPerson, studyAt) =>
-      val size = Math.max(Math.ceil(personKnowsPerson.rdd.getNumPartitions / 10).toInt, 1)
-      undirectedKnowsTemporal(personKnowsPerson)
-        .join(studyAt.as("studyAt1"), $"studyAt1.personId" === $"knows.person1Id")
-        .join(studyAt.as("studyAt2"), $"studyAt2.personId" === $"knows.person2Id")
-        .where($"studyAt1.universityId" === $"studyAt2.universityId")
-        .select(
-          $"knows.person1Id".as("person1Id"),
-          $"knows.person2Id".as("person2Id"),
-          functions.greatest($"knows.creationDate", $"studyAt1.creationDate", $"studyAt2.creationDate").alias("creationDate"),
-          functions.least($"knows.deletionDate", $"studyAt1.deletionDate", $"studyAt2.deletionDate").alias("deletionDate")
-        )
-        .where($"creationDate" < $"deletionDate")
-        .coalesce(size)
-    },
     // -- interactive --
     // first names
     "personFirstNames" -> Factor(PersonType) { case Seq(person) =>
@@ -652,5 +652,22 @@ object FactorGenerationStage extends DatagenStage with Logging {
       )
       numFriendOfFriendCompanies
     },
+    "sameUniversityConnected" -> LargeFactor(PersonType, PersonKnowsPersonType, PersonStudyAtUniversityType) { case Seq(person, personKnowsPerson, studyAt) =>
+      val s = spark
+      import s.implicits._
+      val vertices = person.select("id").rdd.map(row => (row.getAs[Long]("id"), ()))
+
+      val edges = sameUniversityKnows(personKnowsPerson, studyAt).rdd.map(row =>
+        graphx.Edge(row.getAs[Long]("person1Id"), row.getAs[Long]("person2Id"), ())
+      )
+      val graph = graphx.Graph(vertices, edges, ())
+      val cc = graph.connectedComponents().vertices
+        .toDF("PersonId", "Component")
+
+      val counts = cc.groupBy("Component").agg(count("*").as("count"))
+
+      cc.join(counts, Seq("Component")).select("PersonId", "Component", "count")
+
+    }
   )
 }


### PR DESCRIPTION
This PR attempts to solve #404 with a GraphX implementation.

It generates connected components on the full raw graph without deletes, between persons who attended university in overlapping periods of time.

By ignoring deletes, we guarantee that any two disjoint nodes in the result have been so during its full span.
This means that different components can be used as samples for https://github.com/ldbc/ldbc_snb_bi/issues/77 
(a) guaranteed that no path exists


- [x] Requires `spark-graphx`. Have to test whether it is provided on EMR: Yes, it is.
- [ ] We could think about introducing a build switch whether to bundle `spark-graphx` into the jar. Maybe a `--with-spark-graphx` or `--include-spark-graphx`. (I am not sure about `with` as my understanding is that is often used to denote feature switches, and this is not a feature, more like a platform-dependent build directive, that would be used to create the same "whole datagen distribution", no feature is technically added or removed here)




