### PR TITLE
Minor transformation model improvements

### DIFF
--- a/src/main/scala/ldbc/snb/datagen/factors/io/package.scala
+++ b/src/main/scala/ldbc/snb/datagen/factors/io/package.scala
@@ -2,7 +2,7 @@ package ldbc.snb.datagen.factors
 
 import ldbc.snb.datagen.io.dataframes.DataFrameSink
 import ldbc.snb.datagen.io.{PathComponent, Writer}
-import ldbc.snb.datagen.model.{GraphLike, Mode}
+import ldbc.snb.datagen.model.{GraphDef, Mode}
 import ldbc.snb.datagen.syntax._
 import ldbc.snb.datagen.util.Logging
 import org.apache.spark.sql.SaveMode
@@ -17,7 +17,7 @@ package object io {
     override type Data = FactorTable[M]
 
     override def write(self: FactorTable[M], sink: FactorTableSink): Unit = {
-      val p = (sink.path / "factors" / sink.format / PathComponent[GraphLike[M]].path(self.source) / self.name).toString
+      val p = (sink.path / "factors" / sink.format / PathComponent[GraphDef[M]].path(self.source.definition) / self.name).toString
       val dfSink = if (sink.overwrite) {
         DataFrameSink(p, sink.format, mode = SaveMode.Overwrite)
       } else DataFrameSink(p, sink.format)

--- a/src/main/scala/ldbc/snb/datagen/io/PathComponent.scala
+++ b/src/main/scala/ldbc/snb/datagen/io/PathComponent.scala
@@ -1,6 +1,6 @@
 package ldbc.snb.datagen.io
 
-import ldbc.snb.datagen.model.{GraphLike, Mode}
+import ldbc.snb.datagen.model.{GraphDef, Mode}
 
 trait PathComponent[A] {
   def path(a: A): String
@@ -11,7 +11,7 @@ object PathComponent {
 
   private def pure[A](f: A => String) = new PathComponent[A] { override def path(a: A): String = f(a) }
 
-  implicit def pathComponentForGraphDef[M <: Mode] = pure((g: GraphLike[M]) => {
+  implicit def pathComponentForGraphDef[M <: Mode] = pure((g: GraphDef[M]) => {
     val explodedPart = g match {
       case g if g.isAttrExploded && g.isEdgesExploded => "singular-projected-fk"
       case g if g.isAttrExploded                      => "singular-merged-fk"

--- a/src/main/scala/ldbc/snb/datagen/io/graphs.scala
+++ b/src/main/scala/ldbc/snb/datagen/io/graphs.scala
@@ -89,11 +89,12 @@ object graphs {
     import CacheFriendlyEntityOrdering._
 
     override def write(self: Graph[M], sink: GraphSink): Unit = {
+      val spec = self.definition
       TreeMap(self.entities.toSeq: _*).foreach { case (tpe, dataset) =>
         SparkUI.job(getClass.getSimpleName, s"write $tpe") {
-          val p = (sink.path / "graphs" / sink.format / PathComponent[GraphLike[M]].path(self) / tpe.entityPath).toString
+          val p = (sink.path / "graphs" / sink.format / PathComponent[GraphDef[M]].path(spec) / tpe.entityPath).toString
           log.info(s"$tpe: Writing started")
-          val opts = getFormatOptions(sink.format, self.mode, sink.formatOptions)
+          val opts = getFormatOptions(sink.format, spec.mode, sink.formatOptions)
           the(dataset).write(DataFrameSink(p, sink.format, opts, SaveMode.Ignore))
           log.info(s"$tpe: Writing completed")
         }(dataset.sparkSession)
@@ -112,10 +113,11 @@ object graphs {
     import CacheFriendlyEntityOrdering._
 
     override def write(self: Graph[M], sink: GraphSink): Unit = {
-      val opts = getFormatOptions(sink.format, self.mode, sink.formatOptions)
+      val spec = self.definition
+      val opts = getFormatOptions(sink.format, spec.mode, sink.formatOptions)
       TreeMap(self.entities.mapValues(ev).toSeq: _*).foreach { case (tpe, BatchedEntity(snapshot, insertBatches, deleteBatches)) =>
         SparkUI.job(getClass.getSimpleName, s"write $tpe snapshot") {
-          val p = (sink.path / "graphs" / sink.format / PathComponent[GraphLike[M]].path(self) / "initial_snapshot" / tpe.entityPath).toString
+          val p = (sink.path / "graphs" / sink.format / PathComponent[GraphDef[M]].path(spec) / "initial_snapshot" / tpe.entityPath).toString
           log.info(s"$tpe: Writing snapshot")
           snapshot.write(DataFrameSink(p, sink.format, opts, SaveMode.Ignore))
           log.info(s"$tpe: Writing snapshot completed")
@@ -132,7 +134,7 @@ object graphs {
         for { (operation, (batches, sizeFactor)) <- operations } {
           batches.foreach { case Batched(entity, partitionKeys, orderingKeys) =>
             SparkUI.job(getClass.getSimpleName, s"write $tpe $operation") {
-              val p             = (sink.path / "graphs" / sink.format / PathComponent[GraphLike[M]].path(self) / operation / tpe.entityPath).toString
+              val p             = (sink.path / "graphs" / sink.format / PathComponent[GraphDef[M]].path(spec) / operation / tpe.entityPath).toString
               val numPartitions = Math.max(1.0, entity.rdd.getNumPartitions * sizeFactor).toInt
               log.info(f"$tpe: Writing $operation")
               entity
@@ -160,13 +162,13 @@ object graphs {
 
     override def read(self: GraphSource[M]): Graph[M] = {
       val entities = for { (entity, schema) <- self.definition.entities } yield {
-        val p = (self.path / "graphs" / self.format / PathComponent[GraphLike[M]].path(self.definition) / entity.entityPath).toString()
+        val p = (self.path / "graphs" / self.format / PathComponent[GraphDef[M]].path(self.definition) / entity.entityPath).toString()
         log.info(s"Reading $entity")
         val opts = getFormatOptions(self.format, self.definition.mode)
         val df   = DataFrameSource(p, self.format, opts, schema.map(StructType.fromDDL)).read
         entity -> ev(df)
       }
-      Graph[M](self.definition.isAttrExploded, self.definition.isEdgesExploded, self.definition.mode, entities)
+      Graph[M](self.definition, entities)
     }
 
     override def exists(self: GraphSource[M]): Boolean = utils.fileExists(self.path)

--- a/src/main/scala/ldbc/snb/datagen/model/graphs.scala
+++ b/src/main/scala/ldbc/snb/datagen/model/graphs.scala
@@ -12,6 +12,7 @@ object graphs {
     val graphDef = GraphDef(
       isAttrExploded = false,
       isEdgesExploded = false,
+      useTimestamp = false,
       Mode.Raw,
       UntypedEntities[RawEntity].value.map { case (k, v) => (k, Some(v.toDDL)) }
     )

--- a/src/main/scala/ldbc/snb/datagen/model/package.scala
+++ b/src/main/scala/ldbc/snb/datagen/model/package.scala
@@ -149,25 +149,18 @@ package object model {
     }
   }
 
-  trait GraphLike[+M <: Mode] {
-    def isAttrExploded: Boolean
-    def isEdgesExploded: Boolean
-    def mode: M
-  }
-
   case class Graph[+M <: Mode](
-      isAttrExploded: Boolean,
-      isEdgesExploded: Boolean,
-      mode: M,
+      definition: GraphDef[M],
       entities: Map[EntityType, M#Layout]
-  ) extends GraphLike[M]
+  )
 
-  case class GraphDef[M <: Mode](
+  case class GraphDef[+M <: Mode](
       isAttrExploded: Boolean,
       isEdgesExploded: Boolean,
+      useTimestamp: Boolean,
       mode: M,
       entities: Map[EntityType, Option[String]]
-  ) extends GraphLike[M]
+  )
 
   sealed trait BatchPeriod
   object BatchPeriod {

--- a/src/main/scala/ldbc/snb/datagen/transformation/transform/ConvertDates.scala
+++ b/src/main/scala/ldbc/snb/datagen/transformation/transform/ConvertDates.scala
@@ -28,7 +28,7 @@ object ConvertDates {
     implicit def batchedConvertDates[M <: Mode](implicit ev: BatchedEntity =:= M#Layout) = new ConvertDates[M] {
       override def transform(input: In): Out = {
         if (input.definition.useTimestamp) {
-          throw new IllegalArgumentException("Already using timestamp for dates")
+          throw new AssertionError("Already using timestamp for dates")
         }
         val modifiedEntities = input.entities.map { case (tpe, layout) => tpe -> {
           val be = layout.asInstanceOf[BatchedEntity]
@@ -50,7 +50,7 @@ object ConvertDates {
     implicit def simpleConvertDates[M <: Mode](implicit ev: DataFrame =:= M#Layout) = new ConvertDates[M] {
       override def transform(input: In): Out = {
         if (input.definition.useTimestamp) {
-          throw new IllegalArgumentException("Already using timestamp for dates")
+          throw new AssertionError("Already using timestamp for dates")
         }
 
         val modifiedEntities = input.entities

--- a/src/main/scala/ldbc/snb/datagen/transformation/transform/ConvertDates.scala
+++ b/src/main/scala/ldbc/snb/datagen/transformation/transform/ConvertDates.scala
@@ -1,6 +1,6 @@
 package ldbc.snb.datagen.transformation.transform
 
-import ldbc.snb.datagen.model.{Batched, BatchedEntity, EntityType, Mode}
+import ldbc.snb.datagen.model.{Batched, BatchedEntity, EntityType, Graph, Mode}
 import ldbc.snb.datagen.util.sql.qcol
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.lit
@@ -8,6 +8,8 @@ import org.apache.spark.sql.types.{DateType, TimestampType}
 import shapeless._
 
 trait ConvertDates[M <: Mode] extends Transform[M, M] {
+  def convertDatesInEntities(entities: Map[EntityType, M#Layout]): Map[EntityType, (Option[String], M#Layout)]
+
   def convertDates(tpe: EntityType, df: DataFrame): DataFrame = {
     tpe match {
       case tpe if !tpe.isStatic =>
@@ -19,6 +21,23 @@ trait ConvertDates[M <: Mode] extends Transform[M, M] {
       case _ => df
     }
   }
+
+  override def transform(input: Graph[M]): Graph[M] = {
+    if (input.definition.useTimestamp) {
+      throw new AssertionError("Already using timestamp for dates")
+    }
+
+    val updatedEntities = convertDatesInEntities(input.entities)
+
+    val modifiedEntities = updatedEntities
+      .map { case (k, (_, data)) => k -> data }
+
+    val modifiedEntityDefinitions = updatedEntities
+      .map { case (k, (schema, _)) => k -> schema }
+
+    val l = lens[In]
+    (l.definition.useTimestamp ~ l.definition.entities ~ l.entities).set(input)((true, modifiedEntityDefinitions, modifiedEntities))
+  }
 }
 
 object ConvertDates {
@@ -26,41 +45,27 @@ object ConvertDates {
 
   object instances {
     implicit def batchedConvertDates[M <: Mode](implicit ev: BatchedEntity =:= M#Layout) = new ConvertDates[M] {
-      override def transform(input: In): Out = {
-        if (input.definition.useTimestamp) {
-          throw new AssertionError("Already using timestamp for dates")
-        }
-        val modifiedEntities = input.entities.map { case (tpe, layout) => tpe -> {
+      override def convertDatesInEntities(entities: Map[EntityType,M#Layout]): Map[EntityType, (Option[String], M#Layout)] = {
+        entities.map { case (tpe, layout) =>
           val be = layout.asInstanceOf[BatchedEntity]
-          ev(BatchedEntity(
-            convertDates(tpe, be.snapshot),
-            be.insertBatches.map(b => Batched(convertDates(tpe, b.entity), b.batchId, b.ordering)),
-            be.deleteBatches.map(b => Batched(convertDates(tpe, b.entity), b.batchId, b.ordering))
+          val convertedSnapshot = convertDates(tpe, be.snapshot)
+
+          val convertedInserts = be.insertBatches.map(b => Batched(convertDates(tpe, b.entity), b.batchId, b.ordering))
+          val convertedDeletes = be.deleteBatches.map(b => Batched(convertDates(tpe, b.entity), b.batchId, b.ordering))
+          (tpe, (
+            Some(convertedSnapshot.schema.toDDL),
+            ev(BatchedEntity(convertedSnapshot, convertedInserts, convertedDeletes))
           ))
-        }}
-
-        val modifiedEntityDefinitions = modifiedEntities
-          .map { case (tpe, v) => tpe -> Some(v.asInstanceOf[BatchedEntity].snapshot.schema.toDDL) }
-
-        val l = lens[In]
-        (l.definition.useTimestamp ~ l.definition.entities ~ l.entities).set(input)((true, modifiedEntityDefinitions, modifiedEntities))
+        }
       }
     }
 
     implicit def simpleConvertDates[M <: Mode](implicit ev: DataFrame =:= M#Layout) = new ConvertDates[M] {
-      override def transform(input: In): Out = {
-        if (input.definition.useTimestamp) {
-          throw new AssertionError("Already using timestamp for dates")
+      override def convertDatesInEntities(entities: Map[EntityType, M#Layout]): Map[EntityType, (Option[String], M#Layout)] = {
+        entities.map { case (tpe, v) =>
+          val convertedSnapshot = convertDates(tpe, v.asInstanceOf[DataFrame])
+          (tpe, (Some(convertedSnapshot.schema.toDDL), ev(convertedSnapshot)))
         }
-
-        val modifiedEntities = input.entities
-          .map { case (tpe, v) => tpe -> ev(convertDates(tpe, v.asInstanceOf[DataFrame])) }
-
-        val modifiedEntityDefinitions = modifiedEntities
-          .map { case (tpe, v) => tpe -> Some(v.asInstanceOf[DataFrame].schema.toDDL) }
-
-        val l = lens[In]
-        (l.definition.useTimestamp ~ l.definition.entities ~ l.entities).set(input)((true, modifiedEntityDefinitions, modifiedEntities))
       }
     }
   }

--- a/src/main/scala/ldbc/snb/datagen/transformation/transform/ExplodeAttrs.scala
+++ b/src/main/scala/ldbc/snb/datagen/transformation/transform/ExplodeAttrs.scala
@@ -11,7 +11,7 @@ import shapeless.lens
 object ExplodeAttrs extends Transform[Mode.Raw.type, Mode.Raw.type] {
   override def transform(input: In): Out = {
     if (input.definition.isAttrExploded) {
-      throw new IllegalArgumentException("Attributes already exploded in the input graph")
+      throw new AssertionError("Attributes already exploded in the input graph")
     }
 
     def explodedAttr(attr: Attr, node: DataFrame, column: Column) =

--- a/src/main/scala/ldbc/snb/datagen/transformation/transform/ExplodeEdges.scala
+++ b/src/main/scala/ldbc/snb/datagen/transformation/transform/ExplodeEdges.scala
@@ -12,6 +12,9 @@ import shapeless.lens
 
 object ExplodeEdges extends Transform[Mode.Raw.type, Mode.Raw.type] {
   override def transform(input: In): Out = {
+    if (input.definition.isEdgesExploded) {
+          throw new IllegalArgumentException("Edges already exploded in the input graph")
+        }
     val entities = input.entities
 
     def explodedEdge(edge: Edge, node: DataFrame, column: Column) = {
@@ -24,7 +27,7 @@ object ExplodeEdges extends Transform[Mode.Raw.type, Mode.Raw.type] {
       }
     }
 
-    val updatedEntities = entities
+    val modifiedEntities = entities
       .collect {
         case (k @ OrganisationType, v) =>
           Map(
@@ -74,9 +77,16 @@ object ExplodeEdges extends Transform[Mode.Raw.type, Mode.Raw.type] {
             k -> v.drop("CreatorPersonId", "LocationCountryId", "ContainerForumId")
           )
       }
+
+    val updatedEntities = modifiedEntities
       .foldLeft(entities)(_ ++ _)
 
+    val updatedEntityDefinitions = modifiedEntities
+      .foldLeft(input.definition.entities) { (e, v) =>
+        e ++ v.map{ case (k, v) => k -> Some(v.schema.toDDL) }
+      }
+
     val l = lens[In]
-    (l.isEdgesExploded ~ l.entities).set(input)((true, updatedEntities))
+    (l.definition.isEdgesExploded ~ l.definition.entities ~ l.entities).set(input)((true, updatedEntityDefinitions, updatedEntities))
   }
 }

--- a/src/main/scala/ldbc/snb/datagen/transformation/transform/ExplodeEdges.scala
+++ b/src/main/scala/ldbc/snb/datagen/transformation/transform/ExplodeEdges.scala
@@ -13,7 +13,7 @@ import shapeless.lens
 object ExplodeEdges extends Transform[Mode.Raw.type, Mode.Raw.type] {
   override def transform(input: In): Out = {
     if (input.definition.isEdgesExploded) {
-          throw new IllegalArgumentException("Edges already exploded in the input graph")
+          throw new AssertionError("Edges already exploded in the input graph")
         }
     val entities = input.entities
 

--- a/src/main/scala/ldbc/snb/datagen/transformation/transform/RawToBiTransform.scala
+++ b/src/main/scala/ldbc/snb/datagen/transformation/transform/RawToBiTransform.scala
@@ -79,6 +79,16 @@ case class RawToBiTransform(mode: BI, simulationStart: Long, simulationEnd: Long
               None
           )
       }
-    Graph[Mode.BI](isAttrExploded = input.isAttrExploded, isEdgesExploded = input.isEdgesExploded, mode, entities)
+
+    Graph[Mode.BI](
+      GraphDef[Mode.BI](
+        isAttrExploded = input.definition.isAttrExploded,
+        isEdgesExploded = input.definition.isEdgesExploded,
+        useTimestamp = input.definition.useTimestamp,
+        mode = mode,
+        entities = input.definition.entities
+      ),
+      entities
+    )
   }
 }

--- a/src/main/scala/ldbc/snb/datagen/transformation/transform/RawToBiTransform.scala
+++ b/src/main/scala/ldbc/snb/datagen/transformation/transform/RawToBiTransform.scala
@@ -23,7 +23,7 @@ case class RawToBiTransform(mode: BI, simulationStart: Long, simulationEnd: Long
     case "day"    => "yyyy-MM-dd"
     case "hour"   => "yyyy-MM-dd'T'hh"
     case "minute" => "yyyy-MM-dd'T'hh:mm"
-    case _        => throw new IllegalStateException("Unrecognized partition key")
+    case _        => throw new IllegalArgumentException("Unrecognized partition key")
   }
 
   private def notDerived(entityType: EntityType): Boolean = entityType match {

--- a/src/main/scala/ldbc/snb/datagen/transformation/transform/RawToInteractiveTransform.scala
+++ b/src/main/scala/ldbc/snb/datagen/transformation/transform/RawToInteractiveTransform.scala
@@ -3,7 +3,7 @@ package ldbc.snb.datagen.transformation.transform
 import ldbc.snb.datagen.model.Cardinality._
 import ldbc.snb.datagen.model.EntityType._
 import ldbc.snb.datagen.model.raw._
-import ldbc.snb.datagen.model.{EntityType, Graph, Mode}
+import ldbc.snb.datagen.model.{EntityType, Graph, GraphDef, Mode}
 import ldbc.snb.datagen.syntax._
 import ldbc.snb.datagen.util.Logging
 import ldbc.snb.datagen.util.sql._
@@ -22,8 +22,17 @@ case class RawToInteractiveTransform(mode: Mode.Interactive, simulationStart: Lo
       .map { case (tpe, v) =>
         tpe -> RawToInteractiveTransform.snapshotPart(tpe, v, bulkLoadThreshold, filterDeletion = true)
       }
-    Graph[Mode.Interactive](isAttrExploded = input.isAttrExploded, isEdgesExploded = input.isEdgesExploded, mode, entities)
-  }
+    Graph[Mode.Interactive](
+        GraphDef[Mode.Interactive](
+          isAttrExploded = input.definition.isAttrExploded,
+          isEdgesExploded = input.definition.isEdgesExploded,
+          useTimestamp = input.definition.useTimestamp,
+          mode = mode,
+          entities = input.definition.entities
+        ),
+        entities
+      )
+    }
 }
 
 object RawToInteractiveTransform {

--- a/src/main/scala/ldbc/snb/datagen/transformation/transform/Transform.scala
+++ b/src/main/scala/ldbc/snb/datagen/transformation/transform/Transform.scala
@@ -3,10 +3,12 @@ package ldbc.snb.datagen.transformation.transform
 import ldbc.snb.datagen.model.{Graph, Mode}
 import ldbc.snb.datagen.transformation.transform.Transform.DataFrameGraph
 
-trait Transform[M1 <: Mode, M2 <: Mode] {
+trait Transform[M1 <: Mode, M2 <: Mode]
+    extends (DataFrameGraph[M1] => DataFrameGraph[M2]) {
   type In  = DataFrameGraph[M1]
   type Out = DataFrameGraph[M2]
   def transform(input: In): Out
+  override def apply(v1: DataFrameGraph[M1]): DataFrameGraph[M2] = transform(v1)
 }
 
 object Transform {


### PR DESCRIPTION
This PR adds minor changes to the graph metadata used in the transformation chain, in an effort to make it more sensible. 

1. The bogus trait `GraphLike`, that had been introduced to establish a common interface for a graph definition and a graph (with data) has been removed. Instead the graph definition becomes part of the description of the `Graph` by nesting it. We already using something like this for Factor tables, it is a cleaner approach. Everything using `GraphLike` will use `GraphDef` from now on.
2. `GraphDef` gets the `useTimestamp` property indicating whether times are represented as longs in the graph (i.e. `--epoch-millis` option)
3.  Weakly typed transformation steps (ExplodeEdges, ExplodeAttrs and ConvertDates) receive a runtime assertion to guard against illegal use.
4. Transformations update the schema in the entity definitions, to reflect the transformation output faithfully.