### PR TITLE
Clarify Java dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ export SPARK_HOME="${HOME}/spark-3.2.2-bin-hadoop3.2"
 export PATH="${SPARK_HOME}/bin":"${PATH}"
 ```
 
-Both Java 8 and Java 11 are supported.
+Both Java 8 and Java 11 are supported, but Java 17 is not (Spark 3.2.2 will fail, since it uses internal Java APIs and does not set the permissions appropriately).
 
 #### Building the project
 


### PR DESCRIPTION
Java 17 does _not_ work, at least on macOS.

```ShellSession
$ tools/run.py     --cores $(nproc)     --memory ${LDBC_SNB_DATAGEN_MAX_MEM}     --     --format parquet     --scale-factor ${SF}     --mode raw     --output-dir out-sf${SF}     --generate-factors
MMG java -Xmx128m -cp /Users/michaelgreenberg/spark-3.2.2-bin-hadoop3.2/jars/* --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED org.apache.spark.launcher.Main org.apache.spark.deploy.SparkSubmit --master local[8] --class ldbc.snb.datagen.LdbcDatagen --driver-memory 8192m /Users/michaelgreenberg/ldbc_snb_datagen_spark/target/ldbc_snb_datagen_2.12_spark3.2-0.5.1+11-0425cabd-jar-with-dependencies.jar --format parquet --scale-factor 1 --mode raw --output-dir out-sf1 --generate-factors
Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties
23/06/29 11:22:04 INFO SparkContext: Running Spark version 3.2.2
23/06/29 11:22:04 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
23/06/29 11:22:05 INFO ResourceUtils: ==============================================================
23/06/29 11:22:05 INFO ResourceUtils: No custom resources configured for spark.driver.
23/06/29 11:22:05 INFO ResourceUtils: ==============================================================
23/06/29 11:22:05 INFO SparkContext: Submitted application: LDBC SNB Datagen for Spark
23/06/29 11:22:05 INFO ResourceProfile: Default ResourceProfile created, executor resources: Map(cores -> name: cores, amount: 1, script: , vendor: , memory -> name: memory, amount: 1024, script: , vendor: , offHeap -> name: offHeap, amount: 0, script: , vendor: ), task resources: Map(cpus -> name: cpus, amount: 1.0)
23/06/29 11:22:05 INFO ResourceProfile: Limiting resource is cpu
23/06/29 11:22:05 INFO ResourceProfileManager: Added ResourceProfile id: 0
23/06/29 11:22:05 INFO SecurityManager: Changing view acls to: michaelgreenberg
23/06/29 11:22:05 INFO SecurityManager: Changing modify acls to: michaelgreenberg
23/06/29 11:22:05 INFO SecurityManager: Changing view acls groups to: 
23/06/29 11:22:05 INFO SecurityManager: Changing modify acls groups to: 
23/06/29 11:22:05 INFO SecurityManager: SecurityManager: authentication disabled; ui acls disabled; users  with view permissions: Set(michaelgreenberg); groups with view permissions: Set(); users  with modify permissions: Set(michaelgreenberg); groups with modify permissions: Set()
23/06/29 11:22:06 INFO Utils: Successfully started service 'sparkDriver' on port 54074.
23/06/29 11:22:06 INFO SparkEnv: Registering MapOutputTracker
23/06/29 11:22:06 INFO SparkEnv: Registering BlockManagerMaster
23/06/29 11:22:06 INFO BlockManagerMasterEndpoint: Using org.apache.spark.storage.DefaultTopologyMapper for getting topology information
23/06/29 11:22:06 INFO BlockManagerMasterEndpoint: BlockManagerMasterEndpoint up
Exception in thread "main" java.lang.IllegalAccessError: class org.apache.spark.storage.StorageUtils$ (in unnamed module @0x3f3e6f71) cannot access class sun.nio.ch.DirectBuffer (in module java.base) because module java.base does not export sun.nio.ch to unnamed module @0x3f3e6f71
	at org.apache.spark.storage.StorageUtils$.<init>(StorageUtils.scala:213)
	at org.apache.spark.storage.StorageUtils$.<clinit>(StorageUtils.scala)
	at org.apache.spark.storage.BlockManagerMasterEndpoint.<init>(BlockManagerMasterEndpoint.scala:110)
	at org.apache.spark.SparkEnv$.$anonfun$create$9(SparkEnv.scala:348)
	at org.apache.spark.SparkEnv$.registerOrLookupEndpoint$1(SparkEnv.scala:287)
	at org.apache.spark.SparkEnv$.create(SparkEnv.scala:336)
	at org.apache.spark.SparkEnv$.createDriverEnv(SparkEnv.scala:191)
	at org.apache.spark.SparkContext.createSparkEnv(SparkContext.scala:277)
	at org.apache.spark.SparkContext.<init>(SparkContext.scala:460)
	at org.apache.spark.SparkContext$.getOrCreate(SparkContext.scala:2690)
	at org.apache.spark.sql.SparkSession$Builder.$anonfun$getOrCreate$2(SparkSession.scala:949)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.spark.sql.SparkSession$Builder.getOrCreate(SparkSession.scala:943)
	at ldbc.snb.datagen.util.SparkApp.spark(SparkApp.scala:15)
	at ldbc.snb.datagen.util.SparkApp.spark$(SparkApp.scala:12)
	at ldbc.snb.datagen.LdbcDatagen$.spark(LdbcDatagen.scala:13)
	at ldbc.snb.datagen.util.SparkApp.env(SparkApp.scala:25)
	at ldbc.snb.datagen.util.SparkApp.env$(SparkApp.scala:25)
	at ldbc.snb.datagen.LdbcDatagen$.env$lzycompute(LdbcDatagen.scala:13)
	at ldbc.snb.datagen.LdbcDatagen$.env(LdbcDatagen.scala:13)
	at ldbc.snb.datagen.LdbcDatagen$.run(LdbcDatagen.scala:139)
	at ldbc.snb.datagen.LdbcDatagen$.main(LdbcDatagen.scala:135)
	at ldbc.snb.datagen.LdbcDatagen.main(LdbcDatagen.scala)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:578)
	at org.apache.spark.deploy.JavaMainApplication.start(SparkApplication.scala:52)
	at org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:955)
	at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:180)
	at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:203)
	at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:90)
	at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:1043)
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:1052)
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
23/06/29 11:22:06 INFO ShutdownHookManager: Shutdown hook called
23/06/29 11:22:06 INFO ShutdownHookManager: Deleting directory /private/var/folders/6y/r9lg78kn6nq5x707qhn5s9980000gp/T/spark-fdecd335-f283-4fc9-8fe8-3f6ff43cf159
```

The issue is that Spark 3.2.2 tries to use some Java internals that it's not supposed to. I couldn't get the [`--add-opens`/`--add-exports`](https://stackoverflow.com/questions/73465937/apache-spark-3-3-0-breaks-on-java-17-with-cannot-access-class-sun-nio-ch-direct) fix to work, and I'm not willing to debug what goes wrong with a later version of Spark... so downgrading to Java 11 it is.